### PR TITLE
Define msgstore interfaces for mail server suite

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,20 @@
+package msgstore
+
+import "context"
+
+// AuthProvider validates user credentials.
+// Used by smtpd, pop3d, and imapd for authentication.
+type AuthProvider interface {
+	// Authenticate validates credentials and returns user info.
+	// Returns ErrAuthFailed if credentials are invalid.
+	Authenticate(ctx context.Context, username, password string) (*User, error)
+}
+
+// User represents an authenticated mail user.
+type User struct {
+	// Username is the user's login name.
+	Username string
+
+	// Mailbox is the path or identifier for the user's mailbox.
+	Mailbox string
+}

--- a/delivery.go
+++ b/delivery.go
@@ -1,0 +1,35 @@
+package msgstore
+
+import (
+	"context"
+	"io"
+	"net"
+	"time"
+)
+
+// DeliveryAgent handles message delivery to storage.
+// smtpd calls Deliver() after a message passes filtering.
+type DeliveryAgent interface {
+	// Deliver stores a message for the specified recipients.
+	// envelope contains sender and recipient information.
+	// message is the raw RFC 5322 message content.
+	Deliver(ctx context.Context, envelope Envelope, message io.Reader) error
+}
+
+// Envelope contains the message envelope information from the SMTP transaction.
+type Envelope struct {
+	// From is the MAIL FROM address (reverse-path).
+	From string
+
+	// Recipients contains the RCPT TO addresses (forward-paths).
+	Recipients []string
+
+	// ReceivedTime is when the message was received by the server.
+	ReceivedTime time.Time
+
+	// ClientIP is the IP address of the connecting client.
+	ClientIP net.IP
+
+	// ClientHostname is the hostname provided in EHLO/HELO.
+	ClientHostname string
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,43 @@
+// Package errors provides centralized error definitions for msgstore.
+package errors
+
+import "errors"
+
+// Authentication errors.
+var (
+	// ErrAuthFailed indicates authentication credentials are invalid.
+	ErrAuthFailed = errors.New("authentication failed")
+
+	// ErrUserNotFound indicates the requested user does not exist.
+	ErrUserNotFound = errors.New("user not found")
+)
+
+// Mailbox errors.
+var (
+	// ErrMailboxNotFound indicates the requested mailbox does not exist.
+	ErrMailboxNotFound = errors.New("mailbox not found")
+
+	// ErrMailboxLocked indicates the mailbox is locked by another operation.
+	ErrMailboxLocked = errors.New("mailbox locked")
+)
+
+// Message errors.
+var (
+	// ErrMessageNotFound indicates the requested message does not exist.
+	ErrMessageNotFound = errors.New("message not found")
+
+	// ErrMessageDeleted indicates the message has been marked for deletion.
+	ErrMessageDeleted = errors.New("message deleted")
+)
+
+// Delivery errors.
+var (
+	// ErrNoRecipients indicates no valid recipients were provided.
+	ErrNoRecipients = errors.New("no recipients")
+
+	// ErrRecipientNotFound indicates a recipient mailbox does not exist.
+	ErrRecipientNotFound = errors.New("recipient not found")
+
+	// ErrQuotaExceeded indicates the mailbox quota has been exceeded.
+	ErrQuotaExceeded = errors.New("quota exceeded")
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/infodancer/gotemplate
+module github.com/infodancer/msgstore
 
 go 1.23

--- a/store.go
+++ b/store.go
@@ -1,0 +1,40 @@
+package msgstore
+
+import (
+	"context"
+	"io"
+)
+
+// MessageStore provides read access to stored messages.
+// Used by pop3d and imapd for message retrieval.
+type MessageStore interface {
+	// List returns message metadata for a mailbox.
+	List(ctx context.Context, mailbox string) ([]MessageInfo, error)
+
+	// Retrieve returns the full message content.
+	// The caller is responsible for closing the returned ReadCloser.
+	Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error)
+
+	// Delete marks a message for deletion.
+	// The message is not permanently removed until Expunge is called.
+	Delete(ctx context.Context, mailbox string, uid string) error
+
+	// Expunge permanently removes all messages marked for deletion.
+	Expunge(ctx context.Context, mailbox string) error
+
+	// Stat returns mailbox statistics.
+	// count is the number of messages, totalBytes is the sum of all message sizes.
+	Stat(ctx context.Context, mailbox string) (count int, totalBytes int64, err error)
+}
+
+// MessageInfo contains metadata about a stored message.
+type MessageInfo struct {
+	// UID is the unique identifier for the message within the mailbox.
+	UID string
+
+	// Size is the message size in bytes.
+	Size int64
+
+	// Flags contains message flags (e.g., "\Seen", "\Deleted", "\Answered").
+	Flags []string
+}


### PR DESCRIPTION
## Summary

- Define interfaces for message storage shared by smtpd, pop3d, and imapd
- Add `DeliveryAgent` interface for smtpd message delivery
- Add `AuthProvider` interface for shared authentication across daemons
- Add `MessageStore` interface for pop3d/imapd message retrieval
- Add centralized error definitions in `errors/errors.go`
- Update module name from `gotemplate` to `msgstore`
- Update README with project description and architecture diagram

## Test plan

- [x] Verify `task build` succeeds
- [x] Verify `task lint` passes with 0 issues
- [x] Verify `go mod tidy` runs without errors

Closes #1

:robot: Generated with [Claude Code](https://claude.com/claude-code)