### PR TITLE
Add encryption metadata with msgstore as pure blob store

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -1,0 +1,14 @@
+package msgstore
+
+// EncryptionInfo contains metadata about message encryption.
+// This is stored in the Envelope to track encryption state.
+// Note: msgstore never performs encryption or decryption.
+// smtpd encrypts before delivery, pop3d decrypts after retrieval.
+type EncryptionInfo struct {
+	// Algorithm identifies the encryption algorithm used.
+	// Example: "x25519-xsalsa20-poly1305" (NaCl box)
+	Algorithm string
+
+	// Encrypted indicates whether the message content is encrypted.
+	Encrypted bool
+}

--- a/delivery.go
+++ b/delivery.go
@@ -32,4 +32,9 @@ type Envelope struct {
 
 	// ClientHostname is the hostname provided in EHLO/HELO.
 	ClientHostname string
+
+	// Encryption contains metadata about message encryption.
+	// nil indicates plaintext (unencrypted) message.
+	// Note: smtpd encrypts before delivery, msgstore only stores the blob.
+	Encryption *EncryptionInfo
 }


### PR DESCRIPTION
## Summary

- Add `EncryptionInfo` type for tracking encryption metadata in envelopes
- Add `Encryption` field to `Envelope` struct
- Document encryption architecture where **msgstore never sees decrypted data**

### Security Boundaries

| Component | Responsibility |
|-----------|---------------|
| smtpd | Encrypts messages before delivery |
| msgstore | Stores/retrieves encrypted blobs only |
| pop3d | Decrypts messages after retrieval |
| automation | Operates as client with own keypair |

This supersedes #6 with the corrected design.

Closes #7

## Test plan

- [x] Code compiles (`task build`)
- [x] Linter passes (`task lint`)
- [ ] Manual review of interface design

🤖 Generated with [Claude Code](https://claude.com/claude-code)