### PR TITLE
Implement MsgStore interface with registry pattern and maildir subpackage

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -41,3 +41,24 @@ var (
 	// ErrQuotaExceeded indicates the mailbox quota has been exceeded.
 	ErrQuotaExceeded = errors.New("quota exceeded")
 )
+
+// Store errors.
+var (
+	// ErrStoreNotRegistered indicates the requested store type is not registered.
+	ErrStoreNotRegistered = errors.New("store type not registered")
+
+	// ErrStoreConfigInvalid indicates the store configuration is invalid.
+	ErrStoreConfigInvalid = errors.New("invalid store configuration")
+)
+
+// Maildir errors.
+var (
+	// ErrMaildirNotFound indicates the maildir directory does not exist.
+	ErrMaildirNotFound = errors.New("maildir not found")
+
+	// ErrDeliveryFailed indicates message delivery failed.
+	ErrDeliveryFailed = errors.New("delivery failed")
+
+	// ErrInvalidPath indicates an invalid maildir path.
+	ErrInvalidPath = errors.New("invalid maildir path")
+)

--- a/maildir/doc.go
+++ b/maildir/doc.go
@@ -1,0 +1,24 @@
+// Package maildir provides a Maildir-format message store implementation.
+//
+// Maildir is a widely-used format for storing email messages where each message
+// is kept as a separate file. This implementation follows the Maildir specification
+// with the following directory structure:
+//
+//	basePath/
+//	└── user@example.com/
+//	    ├── new/     # Newly delivered messages
+//	    ├── cur/     # Messages that have been seen
+//	    └── tmp/     # Temporary files during delivery
+//
+// The package registers itself with the msgstore registry under the name "maildir".
+// Import it with a blank identifier to enable maildir support:
+//
+//	import _ "github.com/infodancer/msgstore/maildir"
+//
+// Then open a maildir store:
+//
+//	store, err := msgstore.Open(msgstore.StoreConfig{
+//	    Type:     "maildir",
+//	    BasePath: "/var/mail",
+//	})
+package maildir

--- a/maildir/filename.go
+++ b/maildir/filename.go
@@ -1,0 +1,70 @@
+package maildir
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	// deliveryCounter ensures unique filenames even within the same microsecond.
+	deliveryCounter uint64
+	// cachedHostname is set once at startup.
+	cachedHostname string
+)
+
+func init() {
+	cachedHostname = getHostname()
+}
+
+// generateFilename creates a unique filename for maildir delivery.
+// Format: timestamp.Pprocess.hostname.random
+// Example: 1705678901.P12345.hostname.abc123
+func generateFilename() string {
+	now := time.Now()
+	counter := atomic.AddUint64(&deliveryCounter, 1)
+	pid := os.Getpid()
+
+	// Generate random suffix for additional uniqueness
+	randomBytes := make([]byte, 6)
+	if _, err := rand.Read(randomBytes); err != nil {
+		// Fallback to counter-based suffix if random fails
+		return fmt.Sprintf("%d.M%dP%d.%s.%d",
+			now.Unix(),
+			now.Nanosecond()/1000,
+			pid,
+			cachedHostname,
+			counter,
+		)
+	}
+
+	return fmt.Sprintf("%d.M%dP%d.%s.%x",
+		now.Unix(),
+		now.Nanosecond()/1000,
+		pid,
+		cachedHostname,
+		randomBytes,
+	)
+}
+
+// getHostname returns the sanitized system hostname.
+func getHostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+	return sanitizeHostname(hostname)
+}
+
+// sanitizeHostname removes or replaces characters that are problematic in filenames.
+func sanitizeHostname(hostname string) string {
+	// Replace slashes and colons with underscores
+	hostname = strings.ReplaceAll(hostname, "/", "_")
+	hostname = strings.ReplaceAll(hostname, ":", "_")
+	// Remove any other potentially problematic characters
+	hostname = strings.ReplaceAll(hostname, "\x00", "")
+	return hostname
+}

--- a/maildir/maildir.go
+++ b/maildir/maildir.go
@@ -1,0 +1,165 @@
+package maildir
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/infodancer/msgstore/errors"
+)
+
+// Maildir represents a single maildir directory.
+type Maildir struct {
+	path string
+}
+
+// New creates a Maildir instance for the given path.
+// It does not create the directory; use Create() for that.
+func New(path string) *Maildir {
+	return &Maildir{path: path}
+}
+
+// Path returns the maildir path.
+func (m *Maildir) Path() string {
+	return m.path
+}
+
+// Create creates the maildir directory structure (new, cur, tmp).
+func (m *Maildir) Create() error {
+	dirs := []string{
+		filepath.Join(m.path, "new"),
+		filepath.Join(m.path, "cur"),
+		filepath.Join(m.path, "tmp"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Exists checks if the maildir exists and has the required structure.
+func (m *Maildir) Exists() bool {
+	dirs := []string{
+		filepath.Join(m.path, "new"),
+		filepath.Join(m.path, "cur"),
+		filepath.Join(m.path, "tmp"),
+	}
+	for _, dir := range dirs {
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			return false
+		}
+	}
+	return true
+}
+
+// Deliver writes a message to the maildir using the safe delivery process.
+// It writes to tmp/ first, then moves to new/.
+func (m *Maildir) Deliver(message io.Reader) (string, error) {
+	if !m.Exists() {
+		return "", errors.ErrMaildirNotFound
+	}
+
+	filename := generateFilename()
+	tmpPath := filepath.Join(m.path, "tmp", filename)
+	newPath := filepath.Join(m.path, "new", filename)
+
+	// Write to tmp directory
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = io.Copy(f, message)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+
+	// Move from tmp to new
+	if err := os.Rename(tmpPath, newPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+
+	return filename, nil
+}
+
+// Folder returns a Maildir for a subfolder.
+func (m *Maildir) Folder(name string) *Maildir {
+	return New(filepath.Join(m.path, "."+name))
+}
+
+// CreateFolder creates a subfolder maildir.
+func (m *Maildir) CreateFolder(name string) (*Maildir, error) {
+	folder := m.Folder(name)
+	if err := folder.Create(); err != nil {
+		return nil, err
+	}
+	return folder, nil
+}
+
+// ListNew returns the filenames of messages in new/.
+func (m *Maildir) ListNew() ([]string, error) {
+	return m.listDir("new")
+}
+
+// ListCur returns the filenames of messages in cur/.
+func (m *Maildir) ListCur() ([]string, error) {
+	return m.listDir("cur")
+}
+
+func (m *Maildir) listDir(subdir string) ([]string, error) {
+	dir := filepath.Join(m.path, subdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.ErrMaildirNotFound
+		}
+		return nil, err
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			files = append(files, entry.Name())
+		}
+	}
+	return files, nil
+}
+
+// Open opens a message file for reading.
+func (m *Maildir) Open(filename string) (*os.File, error) {
+	// Try cur/ first, then new/
+	curPath := filepath.Join(m.path, "cur", filename)
+	if f, err := os.Open(curPath); err == nil {
+		return f, nil
+	}
+
+	newPath := filepath.Join(m.path, "new", filename)
+	return os.Open(newPath)
+}
+
+// Remove deletes a message file.
+func (m *Maildir) Remove(filename string) error {
+	// Try cur/ first, then new/
+	curPath := filepath.Join(m.path, "cur", filename)
+	if err := os.Remove(curPath); err == nil {
+		return nil
+	}
+
+	newPath := filepath.Join(m.path, "new", filename)
+	return os.Remove(newPath)
+}
+
+// MoveToSeen moves a message from new/ to cur/ (marks as seen).
+func (m *Maildir) MoveToSeen(filename string) error {
+	oldPath := filepath.Join(m.path, "new", filename)
+	newPath := filepath.Join(m.path, "cur", filename)
+	return os.Rename(oldPath, newPath)
+}

--- a/maildir/register.go
+++ b/maildir/register.go
@@ -1,0 +1,15 @@
+package maildir
+
+import (
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/msgstore/errors"
+)
+
+func init() {
+	msgstore.Register("maildir", func(config msgstore.StoreConfig) (msgstore.MsgStore, error) {
+		if config.BasePath == "" {
+			return nil, errors.ErrStoreConfigInvalid
+		}
+		return NewStore(config.BasePath), nil
+	})
+}

--- a/maildir/store.go
+++ b/maildir/store.go
@@ -1,0 +1,256 @@
+package maildir
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/msgstore/errors"
+)
+
+// MaildirStore implements msgstore.MsgStore using the Maildir format.
+type MaildirStore struct {
+	basePath string
+
+	// deleted tracks messages marked for deletion per mailbox.
+	deletedMu sync.Mutex
+	deleted   map[string]map[string]bool // mailbox -> uid -> deleted
+}
+
+// NewStore creates a new MaildirStore with the given base path.
+func NewStore(basePath string) *MaildirStore {
+	return &MaildirStore{
+		basePath: basePath,
+		deleted:  make(map[string]map[string]bool),
+	}
+}
+
+// mailboxPath returns the filesystem path for a mailbox.
+func (s *MaildirStore) mailboxPath(mailbox string) string {
+	// Sanitize mailbox name to prevent path traversal
+	safe := strings.ReplaceAll(mailbox, "..", "")
+	safe = strings.ReplaceAll(safe, "/", "_")
+	return filepath.Join(s.basePath, safe)
+}
+
+// getMaildir returns a Maildir for the given mailbox, creating it if needed.
+func (s *MaildirStore) getMaildir(mailbox string) (*Maildir, error) {
+	path := s.mailboxPath(mailbox)
+	md := New(path)
+	if !md.Exists() {
+		if err := md.Create(); err != nil {
+			return nil, err
+		}
+	}
+	return md, nil
+}
+
+// Deliver implements msgstore.DeliveryAgent.
+func (s *MaildirStore) Deliver(ctx context.Context, envelope msgstore.Envelope, message io.Reader) error {
+	if len(envelope.Recipients) == 0 {
+		return errors.ErrNoRecipients
+	}
+
+	// Read message into memory for multi-recipient delivery
+	data, err := io.ReadAll(message)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	delivered := 0
+
+	for _, recipient := range envelope.Recipients {
+		md, err := s.getMaildir(recipient)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		reader := strings.NewReader(string(data))
+		if _, err := md.Deliver(reader); err != nil {
+			lastErr = err
+			continue
+		}
+		delivered++
+	}
+
+	if delivered == 0 && lastErr != nil {
+		return lastErr
+	}
+	return nil
+}
+
+// List implements msgstore.MessageStore.
+func (s *MaildirStore) List(ctx context.Context, mailbox string) ([]msgstore.MessageInfo, error) {
+	path := s.mailboxPath(mailbox)
+	md := New(path)
+	if !md.Exists() {
+		return nil, errors.ErrMailboxNotFound
+	}
+
+	var messages []msgstore.MessageInfo
+
+	// List messages in new/
+	newFiles, err := md.ListNew()
+	if err != nil && err != errors.ErrMaildirNotFound {
+		return nil, err
+	}
+	for _, filename := range newFiles {
+		if s.isDeleted(mailbox, filename) {
+			continue
+		}
+		info, err := s.getMessageInfo(path, "new", filename)
+		if err != nil {
+			continue
+		}
+		messages = append(messages, info)
+	}
+
+	// List messages in cur/
+	curFiles, err := md.ListCur()
+	if err != nil && err != errors.ErrMaildirNotFound {
+		return nil, err
+	}
+	for _, filename := range curFiles {
+		if s.isDeleted(mailbox, filename) {
+			continue
+		}
+		info, err := s.getMessageInfo(path, "cur", filename)
+		if err != nil {
+			continue
+		}
+		messages = append(messages, info)
+	}
+
+	return messages, nil
+}
+
+func (s *MaildirStore) getMessageInfo(basePath, subdir, filename string) (msgstore.MessageInfo, error) {
+	path := filepath.Join(basePath, subdir, filename)
+	fi, err := os.Stat(path)
+	if err != nil {
+		return msgstore.MessageInfo{}, err
+	}
+
+	// Parse flags from filename (format: unique:2,flags)
+	flags := parseFlags(filename)
+	if subdir == "new" {
+		// Messages in new/ are implicitly unseen
+		flags = append(flags, "\\Recent")
+	}
+
+	return msgstore.MessageInfo{
+		UID:   filename,
+		Size:  fi.Size(),
+		Flags: flags,
+	}, nil
+}
+
+// parseFlags extracts flags from a maildir filename.
+// Format: unique:2,flags where flags are single characters like S, R, T, D, F
+func parseFlags(filename string) []string {
+	var flags []string
+	if idx := strings.Index(filename, ":2,"); idx != -1 {
+		flagStr := filename[idx+3:]
+		for _, c := range flagStr {
+			switch c {
+			case 'S':
+				flags = append(flags, "\\Seen")
+			case 'R':
+				flags = append(flags, "\\Answered")
+			case 'T':
+				flags = append(flags, "\\Deleted")
+			case 'D':
+				flags = append(flags, "\\Draft")
+			case 'F':
+				flags = append(flags, "\\Flagged")
+			}
+		}
+	}
+	return flags
+}
+
+// Retrieve implements msgstore.MessageStore.
+func (s *MaildirStore) Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error) {
+	if s.isDeleted(mailbox, uid) {
+		return nil, errors.ErrMessageDeleted
+	}
+
+	path := s.mailboxPath(mailbox)
+	md := New(path)
+	if !md.Exists() {
+		return nil, errors.ErrMailboxNotFound
+	}
+
+	return md.Open(uid)
+}
+
+// Delete implements msgstore.MessageStore.
+func (s *MaildirStore) Delete(ctx context.Context, mailbox string, uid string) error {
+	s.deletedMu.Lock()
+	defer s.deletedMu.Unlock()
+
+	if s.deleted[mailbox] == nil {
+		s.deleted[mailbox] = make(map[string]bool)
+	}
+	s.deleted[mailbox][uid] = true
+	return nil
+}
+
+// Expunge implements msgstore.MessageStore.
+func (s *MaildirStore) Expunge(ctx context.Context, mailbox string) error {
+	s.deletedMu.Lock()
+	deletedUIDs := s.deleted[mailbox]
+	delete(s.deleted, mailbox)
+	s.deletedMu.Unlock()
+
+	if len(deletedUIDs) == 0 {
+		return nil
+	}
+
+	path := s.mailboxPath(mailbox)
+	md := New(path)
+	if !md.Exists() {
+		return errors.ErrMailboxNotFound
+	}
+
+	var lastErr error
+	for uid := range deletedUIDs {
+		if err := md.Remove(uid); err != nil && !os.IsNotExist(err) {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// Stat implements msgstore.MessageStore.
+func (s *MaildirStore) Stat(ctx context.Context, mailbox string) (count int, totalBytes int64, err error) {
+	messages, err := s.List(ctx, mailbox)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, msg := range messages {
+		count++
+		totalBytes += msg.Size
+	}
+	return count, totalBytes, nil
+}
+
+func (s *MaildirStore) isDeleted(mailbox, uid string) bool {
+	s.deletedMu.Lock()
+	defer s.deletedMu.Unlock()
+
+	if s.deleted[mailbox] == nil {
+		return false
+	}
+	return s.deleted[mailbox][uid]
+}
+
+// Compile-time interface verification.
+var _ msgstore.MsgStore = (*MaildirStore)(nil)

--- a/maildir/store_test.go
+++ b/maildir/store_test.go
@@ -1,0 +1,371 @@
+package maildir
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/msgstore/errors"
+)
+
+func TestMaildirStore_Deliver(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:           "sender@example.com",
+		Recipients:     []string{"user@example.com"},
+		ReceivedTime:   time.Now(),
+		ClientIP:       nil,
+		ClientHostname: "test",
+	}
+
+	message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+
+	err := store.Deliver(ctx, envelope, message)
+	if err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	// Verify message was delivered
+	messages, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+}
+
+func TestMaildirStore_DeliverNoRecipients(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{},
+	}
+
+	message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+
+	err := store.Deliver(ctx, envelope, message)
+	if err != errors.ErrNoRecipients {
+		t.Fatalf("expected ErrNoRecipients, got %v", err)
+	}
+}
+
+func TestMaildirStore_List(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	// Deliver two messages
+	for i := 0; i < 2; i++ {
+		envelope := msgstore.Envelope{
+			From:       "sender@example.com",
+			Recipients: []string{"user@example.com"},
+		}
+		message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+		if err := store.Deliver(ctx, envelope, message); err != nil {
+			t.Fatalf("Deliver failed: %v", err)
+		}
+	}
+
+	messages, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+}
+
+func TestMaildirStore_ListNonexistent(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	_, err := store.List(ctx, "nonexistent@example.com")
+	if err != errors.ErrMailboxNotFound {
+		t.Fatalf("expected ErrMailboxNotFound, got %v", err)
+	}
+}
+
+func TestMaildirStore_Retrieve(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	messageContent := "Subject: Test\r\n\r\nTest message body"
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	message := strings.NewReader(messageContent)
+
+	if err := store.Deliver(ctx, envelope, message); err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	messages, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) == 0 {
+		t.Fatal("no messages found")
+	}
+
+	reader, err := store.Retrieve(ctx, "user@example.com", messages[0].UID)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+
+	if string(data) != messageContent {
+		t.Fatalf("message content mismatch: got %q, want %q", string(data), messageContent)
+	}
+}
+
+func TestMaildirStore_Delete(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+
+	if err := store.Deliver(ctx, envelope, message); err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	messages, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	// Delete the message
+	if err := store.Delete(ctx, "user@example.com", messages[0].UID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Message should no longer appear in list
+	messages, err = store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected 0 messages after delete, got %d", len(messages))
+	}
+}
+
+func TestMaildirStore_Expunge(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+
+	if err := store.Deliver(ctx, envelope, message); err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	messages, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	uid := messages[0].UID
+
+	// Delete and expunge
+	if err := store.Delete(ctx, "user@example.com", uid); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if err := store.Expunge(ctx, "user@example.com"); err != nil {
+		t.Fatalf("Expunge failed: %v", err)
+	}
+
+	// Retrieve should fail after expunge
+	_, err = store.Retrieve(ctx, "user@example.com", uid)
+	if err == nil {
+		t.Fatal("expected error after expunge, got nil")
+	}
+}
+
+func TestMaildirStore_Stat(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	// Deliver messages
+	for i := 0; i < 3; i++ {
+		envelope := msgstore.Envelope{
+			From:       "sender@example.com",
+			Recipients: []string{"user@example.com"},
+		}
+		message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+		if err := store.Deliver(ctx, envelope, message); err != nil {
+			t.Fatalf("Deliver failed: %v", err)
+		}
+	}
+
+	count, totalBytes, err := store.Stat(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 messages, got %d", count)
+	}
+	if totalBytes == 0 {
+		t.Fatal("expected non-zero total bytes")
+	}
+}
+
+func TestMaildirStore_MultipleRecipients(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath)
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user1@example.com", "user2@example.com"},
+	}
+	message := strings.NewReader("Subject: Test\r\n\r\nTest message body")
+
+	if err := store.Deliver(ctx, envelope, message); err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	// Both users should have the message
+	for _, user := range envelope.Recipients {
+		messages, err := store.List(ctx, user)
+		if err != nil {
+			t.Fatalf("List failed for %s: %v", user, err)
+		}
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message for %s, got %d", user, len(messages))
+		}
+	}
+}
+
+func TestMaildir_Create(t *testing.T) {
+	basePath := t.TempDir()
+	md := New(basePath + "/testmaildir")
+
+	if md.Exists() {
+		t.Fatal("maildir should not exist before Create")
+	}
+
+	if err := md.Create(); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if !md.Exists() {
+		t.Fatal("maildir should exist after Create")
+	}
+}
+
+func TestMaildir_Deliver(t *testing.T) {
+	basePath := t.TempDir()
+	md := New(basePath + "/testmaildir")
+
+	if err := md.Create(); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	message := strings.NewReader("Subject: Test\r\n\r\nTest body")
+	filename, err := md.Deliver(message)
+	if err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+	if filename == "" {
+		t.Fatal("expected non-empty filename")
+	}
+
+	// Verify file exists in new/
+	files, err := md.ListNew()
+	if err != nil {
+		t.Fatalf("ListNew failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file in new/, got %d", len(files))
+	}
+	if files[0] != filename {
+		t.Fatalf("filename mismatch: got %s, want %s", files[0], filename)
+	}
+}
+
+func TestGenerateFilename(t *testing.T) {
+	filename1 := generateFilename()
+	filename2 := generateFilename()
+
+	if filename1 == "" {
+		t.Fatal("expected non-empty filename")
+	}
+	if filename1 == filename2 {
+		t.Fatal("expected unique filenames")
+	}
+}
+
+func TestSanitizeHostname(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"localhost", "localhost"},
+		{"host/name", "host_name"},
+		{"host:name", "host_name"},
+		{"host/name:test", "host_name_test"},
+	}
+
+	for _, tt := range tests {
+		result := sanitizeHostname(tt.input)
+		if result != tt.expected {
+			t.Errorf("sanitizeHostname(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		filename string
+		expected []string
+	}{
+		{"1234567890.P123.hostname", nil},
+		{"1234567890.P123.hostname:2,S", []string{"\\Seen"}},
+		{"1234567890.P123.hostname:2,SR", []string{"\\Seen", "\\Answered"}},
+		{"1234567890.P123.hostname:2,SRTDF", []string{"\\Seen", "\\Answered", "\\Deleted", "\\Draft", "\\Flagged"}},
+	}
+
+	for _, tt := range tests {
+		result := parseFlags(tt.filename)
+		if len(result) != len(tt.expected) {
+			t.Errorf("parseFlags(%q) = %v, want %v", tt.filename, result, tt.expected)
+			continue
+		}
+		for i := range result {
+			if result[i] != tt.expected[i] {
+				t.Errorf("parseFlags(%q) = %v, want %v", tt.filename, result, tt.expected)
+				break
+			}
+		}
+	}
+}

--- a/msgstore.go
+++ b/msgstore.go
@@ -1,0 +1,9 @@
+package msgstore
+
+// MsgStore combines delivery and storage operations.
+// It embeds both DeliveryAgent (for smtpd message delivery) and
+// MessageStore (for pop3d/imapd message retrieval).
+type MsgStore interface {
+	DeliveryAgent
+	MessageStore
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,73 @@
+package msgstore
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/infodancer/msgstore/errors"
+)
+
+// StoreFactory creates a MsgStore from configuration.
+type StoreFactory func(config StoreConfig) (MsgStore, error)
+
+// StoreConfig contains settings for opening a store.
+type StoreConfig struct {
+	// Type is the store type name (e.g., "maildir", "mbox").
+	Type string
+
+	// BasePath is the root directory for file-based stores.
+	BasePath string
+
+	// Options contains implementation-specific settings.
+	Options map[string]string
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]StoreFactory)
+)
+
+// Register adds a store factory to the registry.
+// It panics if called with an empty name or nil factory,
+// or if the name is already registered.
+func Register(name string, factory StoreFactory) {
+	if name == "" {
+		panic("msgstore: Register called with empty name")
+	}
+	if factory == nil {
+		panic("msgstore: Register called with nil factory")
+	}
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if _, exists := registry[name]; exists {
+		panic("msgstore: Register called twice for " + name)
+	}
+	registry[name] = factory
+}
+
+// Open creates a MsgStore using the registered factory for the config type.
+func Open(config StoreConfig) (MsgStore, error) {
+	registryMu.RLock()
+	factory, ok := registry[config.Type]
+	registryMu.RUnlock()
+
+	if !ok {
+		return nil, errors.ErrStoreNotRegistered
+	}
+	return factory(config)
+}
+
+// RegisteredTypes returns a sorted list of registered store type names.
+func RegisteredTypes() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	types := make([]string, 0, len(registry))
+	for name := range registry {
+		types = append(types, name)
+	}
+	sort.Strings(types)
+	return types
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,145 @@
+package msgstore_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/infodancer/msgstore"
+	"github.com/infodancer/msgstore/errors"
+
+	// Import maildir to trigger registration
+	_ "github.com/infodancer/msgstore/maildir"
+)
+
+func TestRegisteredTypes(t *testing.T) {
+	types := msgstore.RegisteredTypes()
+	if len(types) == 0 {
+		t.Fatal("expected at least one registered type")
+	}
+
+	// maildir should be registered via init()
+	found := false
+	for _, typ := range types {
+		if typ == "maildir" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("maildir not found in registered types: %v", types)
+	}
+}
+
+func TestOpen(t *testing.T) {
+	basePath := t.TempDir()
+
+	store, err := msgstore.Open(msgstore.StoreConfig{
+		Type:     "maildir",
+		BasePath: basePath,
+	})
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestOpenUnregistered(t *testing.T) {
+	_, err := msgstore.Open(msgstore.StoreConfig{
+		Type:     "nonexistent",
+		BasePath: "/tmp",
+	})
+	if err != errors.ErrStoreNotRegistered {
+		t.Fatalf("expected ErrStoreNotRegistered, got %v", err)
+	}
+}
+
+func TestOpenInvalidConfig(t *testing.T) {
+	_, err := msgstore.Open(msgstore.StoreConfig{
+		Type:     "maildir",
+		BasePath: "", // invalid - empty path
+	})
+	if err != errors.ErrStoreConfigInvalid {
+		t.Fatalf("expected ErrStoreConfigInvalid, got %v", err)
+	}
+}
+
+func TestMsgStoreInterface(t *testing.T) {
+	basePath := t.TempDir()
+
+	store, err := msgstore.Open(msgstore.StoreConfig{
+		Type:     "maildir",
+		BasePath: basePath,
+	})
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+
+	ctx := context.Background()
+	mailbox := "test@example.com"
+
+	// Test Deliver (DeliveryAgent)
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{mailbox},
+	}
+	message := strings.NewReader("Subject: Test\r\n\r\nTest body")
+
+	if err := store.Deliver(ctx, envelope, message); err != nil {
+		t.Fatalf("Deliver failed: %v", err)
+	}
+
+	// Test List (MessageStore)
+	messages, err := store.List(ctx, mailbox)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+
+	// Test Retrieve (MessageStore)
+	reader, err := store.Retrieve(ctx, mailbox, messages[0].UID)
+	if err != nil {
+		t.Fatalf("Retrieve failed: %v", err)
+	}
+	data, _ := io.ReadAll(reader)
+	_ = reader.Close()
+	if !strings.Contains(string(data), "Test body") {
+		t.Fatal("message content not found")
+	}
+
+	// Test Stat (MessageStore)
+	count, bytes, err := store.Stat(ctx, mailbox)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected count 1, got %d", count)
+	}
+	if bytes == 0 {
+		t.Fatal("expected non-zero bytes")
+	}
+
+	// Test Delete (MessageStore)
+	if err := store.Delete(ctx, mailbox, messages[0].UID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Test Expunge (MessageStore)
+	if err := store.Expunge(ctx, mailbox); err != nil {
+		t.Fatalf("Expunge failed: %v", err)
+	}
+
+	// Verify message is gone
+	messages, err = store.List(ctx, mailbox)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected 0 messages after expunge, got %d", len(messages))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `MsgStore` interface combining `DeliveryAgent` and `MessageStore` interfaces
- Implement registry/factory pattern for pluggable store implementations
- Create `maildir` subpackage with complete Maildir-format implementation

### New Files

| File | Description |
|------|-------------|
| `msgstore.go` | MsgStore interface definition |
| `registry.go` | Registry pattern with Register(), Open(), RegisteredTypes() |
| `registry_test.go` | Registry and integration tests |
| `maildir/doc.go` | Package documentation |
| `maildir/maildir.go` | Core Maildir type with directory operations |
| `maildir/filename.go` | Unique filename generation for delivery |
| `maildir/store.go` | MaildirStore implementing MsgStore interface |
| `maildir/store_test.go` | Comprehensive maildir tests |
| `maildir/register.go` | Self-registration via init() |

### Updated Files

- `errors/errors.go` - Added store and maildir errors

## Test plan

- [x] `go build ./...` compiles without errors
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run` no lint errors

Resolves https://github.com/infodancer/msgstore/issues/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)