### PR TITLE
Bump auth to v0.1.2; document encryption, Sieve, and concurrency plans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9
 	github.com/emersion/go-maildir v0.6.0
-	github.com/infodancer/auth v0.1.0
+	github.com/infodancer/auth v0.1.2
 	golang.org/x/crypto v0.47.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9 h1:MaPyH1+nMX0az
 git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9/go.mod h1:ewD6qhJ+zMwEeAElDEJOYYdkpxZSHRodJwq9Z0OG30w=
 github.com/emersion/go-maildir v0.6.0 h1:MPx2RSS1Xq8j1cNOzfq7YyF+5Leoeif1XqSeuytdET8=
 github.com/emersion/go-maildir v0.6.0/go.mod h1:Wpgtt9EOIJWe++WKa+JRvDwv+qIV7MeFdvZu/VbsXN4=
-github.com/infodancer/auth v0.1.0 h1:/mK/qST+vHK5Q12Y0pK389Rp80D0cra96pp0FJNSPAI=
-github.com/infodancer/auth v0.1.0/go.mod h1:rMMSXMH8icBAACj40geMonedM5WBIcE1MUxvN9AJagg=
+github.com/infodancer/auth v0.1.2 h1:F51ZBrjlecJ5v0WLJyzJcaDU6C/oDrHkORm5tpWl36g=
+github.com/infodancer/auth v0.1.2/go.mod h1:rMMSXMH8icBAACj40geMonedM5WBIcE1MUxvN9AJagg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=


### PR DESCRIPTION
## Summary

- Updates `auth` dependency from `v0.1.0` to `v0.1.2` to match the rest of the workspace
- Reframes the encryption section in README as planned future architecture (not current capability)
- Documents Sieve as planned — parser is present but evaluation is deferred to a future milestone
- Adds a Concurrency section clarifying Maildir atomicity guarantees and that soft-delete state is per-instance

## Why now

These are the final documentation and dependency fixes needed before tagging `v0.1.0`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)