### PR TITLE
Add no-op PassthroughDecryptingStore implementation

### DIFF
--- a/decrypting_store.go
+++ b/decrypting_store.go
@@ -1,0 +1,71 @@
+package msgstore
+
+import (
+	"context"
+	"io"
+)
+
+// PassthroughDecryptingStore implements DecryptingStore as a transparent
+// passthrough. All MessageStore operations are delegated to the underlying
+// store unchanged. SetSessionKey stores the key in memory (zeroing it on
+// ClearSessionKey) but does not yet perform decryption.
+//
+// This implementation provides the plumbing for the fd-based key-passing
+// convention between pop3d/imapd and mail-session. A real DecryptingStore
+// implementation that calls DecryptMessage on retrieved bytes will replace
+// or wrap this when at-rest encryption is fully wired in.
+type PassthroughDecryptingStore struct {
+	underlying MessageStore
+	sessionKey []byte
+}
+
+// Compile-time interface check.
+var _ DecryptingStore = (*PassthroughDecryptingStore)(nil)
+
+// NewPassthroughDecryptingStore wraps underlying in a PassthroughDecryptingStore.
+func NewPassthroughDecryptingStore(underlying MessageStore) *PassthroughDecryptingStore {
+	return &PassthroughDecryptingStore{underlying: underlying}
+}
+
+// SetSessionKey stores the session key for future decryption use.
+// The key is copied; the caller may zero its buffer after this call.
+func (s *PassthroughDecryptingStore) SetSessionKey(key []byte) {
+	cp := make([]byte, len(key))
+	copy(cp, key)
+	s.sessionKey = cp
+}
+
+// ClearSessionKey zeroes the stored key bytes and releases the slice.
+func (s *PassthroughDecryptingStore) ClearSessionKey() {
+	for i := range s.sessionKey {
+		s.sessionKey[i] = 0
+	}
+	s.sessionKey = nil
+}
+
+// List delegates to the underlying store.
+func (s *PassthroughDecryptingStore) List(ctx context.Context, mailbox string) ([]MessageInfo, error) {
+	return s.underlying.List(ctx, mailbox)
+}
+
+// Retrieve delegates to the underlying store.
+// When decryption is implemented, this method will call DecryptMessage on
+// the returned content when sessionKey is non-nil.
+func (s *PassthroughDecryptingStore) Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error) {
+	return s.underlying.Retrieve(ctx, mailbox, uid)
+}
+
+// Delete delegates to the underlying store.
+func (s *PassthroughDecryptingStore) Delete(ctx context.Context, mailbox string, uid string) error {
+	return s.underlying.Delete(ctx, mailbox, uid)
+}
+
+// Expunge delegates to the underlying store.
+func (s *PassthroughDecryptingStore) Expunge(ctx context.Context, mailbox string) error {
+	return s.underlying.Expunge(ctx, mailbox)
+}
+
+// Stat delegates to the underlying store.
+func (s *PassthroughDecryptingStore) Stat(ctx context.Context, mailbox string) (int, int64, error) {
+	return s.underlying.Stat(ctx, mailbox)
+}

--- a/decrypting_store_test.go
+++ b/decrypting_store_test.go
@@ -1,0 +1,139 @@
+package msgstore
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+)
+
+// mockStore is a minimal MessageStore for testing PassthroughDecryptingStore.
+type mockStore struct {
+	listCalled     bool
+	retrieveCalled bool
+	deleteCalled   bool
+	expungeCalled  bool
+	statCalled     bool
+}
+
+func (m *mockStore) List(_ context.Context, _ string) ([]MessageInfo, error) {
+	m.listCalled = true
+	return []MessageInfo{{UID: "1", Size: 42}}, nil
+}
+
+func (m *mockStore) Retrieve(_ context.Context, _ string, _ string) (io.ReadCloser, error) {
+	m.retrieveCalled = true
+	return io.NopCloser(bytes.NewReader([]byte("hello"))), nil
+}
+
+func (m *mockStore) Delete(_ context.Context, _ string, _ string) error {
+	m.deleteCalled = true
+	return nil
+}
+
+func (m *mockStore) Expunge(_ context.Context, _ string) error {
+	m.expungeCalled = true
+	return nil
+}
+
+func (m *mockStore) Stat(_ context.Context, _ string) (int, int64, error) {
+	m.statCalled = true
+	return 1, 42, nil
+}
+
+func TestPassthroughDecryptingStore_PassesThrough(t *testing.T) {
+	ctx := context.Background()
+	mock := &mockStore{}
+	store := NewPassthroughDecryptingStore(mock)
+
+	if _, err := store.List(ctx, "inbox"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !mock.listCalled {
+		t.Error("List not delegated to underlying store")
+	}
+
+	if _, err := store.Retrieve(ctx, "inbox", "1"); err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if !mock.retrieveCalled {
+		t.Error("Retrieve not delegated to underlying store")
+	}
+
+	if err := store.Delete(ctx, "inbox", "1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !mock.deleteCalled {
+		t.Error("Delete not delegated to underlying store")
+	}
+
+	if err := store.Expunge(ctx, "inbox"); err != nil {
+		t.Fatalf("Expunge: %v", err)
+	}
+	if !mock.expungeCalled {
+		t.Error("Expunge not delegated to underlying store")
+	}
+
+	if _, _, err := store.Stat(ctx, "inbox"); err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !mock.statCalled {
+		t.Error("Stat not delegated to underlying store")
+	}
+}
+
+func TestPassthroughDecryptingStore_SetAndClearSessionKey(t *testing.T) {
+	store := NewPassthroughDecryptingStore(&mockStore{})
+
+	key := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	store.SetSessionKey(key)
+
+	if len(store.sessionKey) != len(key) {
+		t.Fatalf("expected sessionKey length %d, got %d", len(key), len(store.sessionKey))
+	}
+	for i, b := range key {
+		if store.sessionKey[i] != b {
+			t.Errorf("sessionKey[%d]: got %d, want %d", i, store.sessionKey[i], b)
+		}
+	}
+
+	// Verify the stored key is a copy, not the original slice.
+	key[0] = 0xFF
+	if store.sessionKey[0] == 0xFF {
+		t.Error("SetSessionKey should copy the key, not store a reference")
+	}
+
+	store.ClearSessionKey()
+
+	if store.sessionKey != nil {
+		t.Error("sessionKey should be nil after ClearSessionKey")
+	}
+}
+
+func TestPassthroughDecryptingStore_ClearSessionKey_ZeroesBytes(t *testing.T) {
+	store := NewPassthroughDecryptingStore(&mockStore{})
+
+	key := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	store.SetSessionKey(key)
+
+	// Capture a reference to the internal slice before clearing.
+	internal := store.sessionKey
+
+	store.ClearSessionKey()
+
+	// The bytes that were in the slice should be zeroed.
+	for i, b := range internal {
+		if b != 0 {
+			t.Errorf("byte %d not zeroed after ClearSessionKey: got %d", i, b)
+		}
+	}
+}
+
+func TestPassthroughDecryptingStore_SatisfiesDecryptingStore(_ *testing.T) {
+	// Compile-time check; if this compiles, the interface is satisfied.
+	var _ DecryptingStore = NewPassthroughDecryptingStore(&mockStore{})
+}
+
+// Ensure mockStore satisfies MessageStore at compile time.
+var _ MessageStore = (*mockStore)(nil)
+


### PR DESCRIPTION
## Summary
- Implements \`DecryptingStore\` interface as \`PassthroughDecryptingStore\`
- Wraps any \`MessageStore\`; all operations pass through unchanged
- \`SetSessionKey\` stores key bytes (copies); \`ClearSessionKey\` zeroes them before releasing
- Compile-time interface check ensures it stays in sync with the interface
- Part of the encryption plumbing series

## Test plan
- [x] Compile-time interface assertion passes
- [x] MessageStore methods pass through to underlying store
- [x] \`ClearSessionKey\` zeroes key bytes (verified via captured slice reference)
- [x] \`SetSessionKey\` copies the key (not a reference)
- [x] \`go test ./...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)