### PR TITLE
Add persistent IMAP UIDs via .uidlist file

### DIFF
--- a/decrypting_store.go
+++ b/decrypting_store.go
@@ -51,12 +51,12 @@ func (s *PassthroughDecryptingStore) List(ctx context.Context, mailbox string) (
 // Retrieve delegates to the underlying store.
 // When decryption is implemented, this method will call DecryptMessage on
 // the returned content when sessionKey is non-nil.
-func (s *PassthroughDecryptingStore) Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error) {
+func (s *PassthroughDecryptingStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	return s.underlying.Retrieve(ctx, mailbox, uid)
 }
 
 // Delete delegates to the underlying store.
-func (s *PassthroughDecryptingStore) Delete(ctx context.Context, mailbox string, uid string) error {
+func (s *PassthroughDecryptingStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	return s.underlying.Delete(ctx, mailbox, uid)
 }
 

--- a/decrypting_store_test.go
+++ b/decrypting_store_test.go
@@ -18,15 +18,15 @@ type mockStore struct {
 
 func (m *mockStore) List(_ context.Context, _ string) ([]MessageInfo, error) {
 	m.listCalled = true
-	return []MessageInfo{{UID: "1", Size: 42}}, nil
+	return []MessageInfo{{UID: 1, Size: 42}}, nil
 }
 
-func (m *mockStore) Retrieve(_ context.Context, _ string, _ string) (io.ReadCloser, error) {
+func (m *mockStore) Retrieve(_ context.Context, _ string, _ uint32) (io.ReadCloser, error) {
 	m.retrieveCalled = true
 	return io.NopCloser(bytes.NewReader([]byte("hello"))), nil
 }
 
-func (m *mockStore) Delete(_ context.Context, _ string, _ string) error {
+func (m *mockStore) Delete(_ context.Context, _ string, _ uint32) error {
 	m.deleteCalled = true
 	return nil
 }
@@ -53,14 +53,14 @@ func TestPassthroughDecryptingStore_PassesThrough(t *testing.T) {
 		t.Error("List not delegated to underlying store")
 	}
 
-	if _, err := store.Retrieve(ctx, "inbox", "1"); err != nil {
+	if _, err := store.Retrieve(ctx, "inbox", 1); err != nil {
 		t.Fatalf("Retrieve: %v", err)
 	}
 	if !mock.retrieveCalled {
 		t.Error("Retrieve not delegated to underlying store")
 	}
 
-	if err := store.Delete(ctx, "inbox", "1"); err != nil {
+	if err := store.Delete(ctx, "inbox", 1); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	if !mock.deleteCalled {
@@ -136,4 +136,3 @@ func TestPassthroughDecryptingStore_SatisfiesDecryptingStore(_ *testing.T) {
 
 // Ensure mockStore satisfies MessageStore at compile time.
 var _ MessageStore = (*mockStore)(nil)
-

--- a/maildir/store.go
+++ b/maildir/store.go
@@ -3,7 +3,6 @@ package maildir
 import (
 	"bytes"
 	"context"
-	"hash/fnv"
 	"io"
 	"log/slog"
 	"os"
@@ -25,10 +24,15 @@ type MaildirStore struct {
 	maildirSubdir string // optional subdirectory under each mailbox (e.g., "Maildir")
 	pathTemplate  string // optional path template for domain-aware storage
 
-	// deleted tracks messages marked for deletion.
+	// deleted tracks messages marked for deletion by uint32 UID.
 	// Keys are mailbox names for INBOX, or composite keys for folders.
 	deletedMu sync.Mutex
-	deleted   map[string]map[string]bool // key -> uid -> deleted
+	deleted   map[string]map[uint32]bool // deletion key -> uid -> deleted
+
+	// uidlistCache caches parsed uidlists per folder path.
+	// Invalidated on mutating operations (Deliver, Append, Copy, Expunge).
+	uidlistMu    sync.Mutex
+	uidlistCache map[string]*uidList // folder path -> uidlist
 }
 
 // NewStore creates a new MaildirStore with the given base path.
@@ -41,7 +45,8 @@ func NewStore(basePath string, maildirSubdir string, pathTemplate string) *Maild
 		basePath:      basePath,
 		maildirSubdir: maildirSubdir,
 		pathTemplate:  pathTemplate,
-		deleted:       make(map[string]map[string]bool),
+		deleted:       make(map[string]map[uint32]bool),
+		uidlistCache:  make(map[string]*uidList),
 	}
 }
 
@@ -154,6 +159,7 @@ func (s *MaildirStore) EnsureDefaultFolders(ctx context.Context, mailbox string)
 
 // listDir returns message metadata for all non-deleted messages in the given maildir path.
 // deletionKey identifies which set of soft-deleted messages to filter out.
+// Messages are returned sorted by UID ascending with persistent UIDs from .uidlist.
 func (s *MaildirStore) listDir(path string, deletionKey string) ([]msgstore.MessageInfo, error) {
 	dir := maildir.Dir(path)
 
@@ -170,34 +176,63 @@ func (s *MaildirStore) listDir(path string, deletionKey string) ([]msgstore.Mess
 		recentKeys[msg.Key()] = true
 	}
 
-	// Now get all messages (which are all in cur/ after Unseen())
-	allMsgs, err := dir.Messages()
+	// Load/reconcile uidlist against current cur/ contents.
+	keys, err := curDirKeys(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var messages []msgstore.MessageInfo
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return nil, err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	unlockUIDList(lock)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the uidlist for subsequent Retrieve/Delete calls.
+	s.cacheUIDList(path, ul)
+
+	// Build a map from key to go-maildir Message for flag/stat lookup.
+	allMsgs, err := dir.Messages()
+	if err != nil {
+		return nil, err
+	}
+	msgByKey := make(map[string]*maildir.Message, len(allMsgs))
 	for _, msg := range allMsgs {
-		key := msg.Key()
-		if s.isDeleted(deletionKey, key) {
+		msgByKey[msg.Key()] = msg
+	}
+
+	// Walk uidlist entries (sorted by UID ascending) to build results.
+	var messages []msgstore.MessageInfo
+	for _, entry := range ul.entries {
+		if s.isDeleted(deletionKey, entry.uid) {
 			continue
+		}
+
+		msg, ok := msgByKey[entry.key]
+		if !ok {
+			continue // Key in uidlist but not in cur/; already reconciled
 		}
 
 		filename := msg.Filename()
 		fi, err := os.Stat(filename)
 		if err != nil {
-			continue // Skip on error
+			continue
 		}
 
 		flags := msg.Flags()
 		var flagStrings []string
-		if recentKeys[key] {
+		if recentKeys[entry.key] {
 			flagStrings = append(flagStrings, "\\Recent")
 		}
 		flagStrings = append(flagStrings, convertFlags(flags)...)
 
 		messages = append(messages, msgstore.MessageInfo{
-			UID:          key,
+			UID:          entry.uid,
+			Key:          entry.key,
 			Size:         fi.Size(),
 			Flags:        flagStrings,
 			InternalDate: fi.ModTime(),
@@ -207,22 +242,72 @@ func (s *MaildirStore) listDir(path string, deletionKey string) ([]msgstore.Mess
 	return messages, nil
 }
 
-// retrieveFromDir retrieves a single message from the given maildir path.
-func (s *MaildirStore) retrieveFromDir(path string, uid string) (io.ReadCloser, error) {
+// cacheUIDList stores a uidlist in the per-folder cache.
+func (s *MaildirStore) cacheUIDList(path string, ul *uidList) {
+	s.uidlistMu.Lock()
+	s.uidlistCache[path] = ul
+	s.uidlistMu.Unlock()
+}
+
+// invalidateUIDListCache removes a cached uidlist for the given path.
+func (s *MaildirStore) invalidateUIDListCache(path string) {
+	s.uidlistMu.Lock()
+	delete(s.uidlistCache, path)
+	s.uidlistMu.Unlock()
+}
+
+// lookupKey resolves a uint32 UID to its Maildir key using the cache or disk.
+func (s *MaildirStore) lookupKey(path string, uid uint32) (string, error) {
+	// Try cache first.
+	s.uidlistMu.Lock()
+	if ul, ok := s.uidlistCache[path]; ok {
+		s.uidlistMu.Unlock()
+		if key, ok := ul.uidToKey[uid]; ok {
+			return key, nil
+		}
+		return "", errors.ErrMessageNotFound
+	}
+	s.uidlistMu.Unlock()
+
+	// Cache miss — load from disk.
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return "", err
+	}
+	keys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return "", err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	unlockUIDList(lock)
+	if err != nil {
+		return "", err
+	}
+	s.cacheUIDList(path, ul)
+
+	if key, ok := ul.uidToKey[uid]; ok {
+		return key, nil
+	}
+	return "", errors.ErrMessageNotFound
+}
+
+// retrieveFromDir retrieves a single message from the given maildir path by Maildir key.
+func (s *MaildirStore) retrieveFromDir(path string, key string) (io.ReadCloser, error) {
 	dir := maildir.Dir(path)
-	msg, err := dir.MessageByKey(uid)
+	msg, err := dir.MessageByKey(key)
 	if err != nil {
 		return nil, err
 	}
 	return msg.Open()
 }
 
-// removeMessages permanently removes the specified messages from a maildir.
-func (s *MaildirStore) removeMessages(path string, uids map[string]bool) error {
+// removeMessages permanently removes the specified messages from a maildir by key.
+func (s *MaildirStore) removeMessages(path string, keys map[string]bool) error {
 	dir := maildir.Dir(path)
 	var lastErr error
-	for uid := range uids {
-		msg, err := dir.MessageByKey(uid)
+	for key := range keys {
+		msg, err := dir.MessageByKey(key)
 		if err != nil {
 			// Message might not exist, skip
 			continue
@@ -254,7 +339,7 @@ func convertFlags(flags []maildir.Flag) []string {
 	return result
 }
 
-func (s *MaildirStore) isDeleted(key, uid string) bool {
+func (s *MaildirStore) isDeleted(key string, uid uint32) bool {
 	s.deletedMu.Lock()
 	defer s.deletedMu.Unlock()
 
@@ -360,7 +445,7 @@ func (s *MaildirStore) List(ctx context.Context, mailbox string) ([]msgstore.Mes
 }
 
 // Retrieve implements msgstore.MessageStore.
-func (s *MaildirStore) Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error) {
+func (s *MaildirStore) Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error) {
 	if s.isDeleted(mailbox, uid) {
 		return nil, errors.ErrMessageDeleted
 	}
@@ -370,22 +455,26 @@ func (s *MaildirStore) Retrieve(ctx context.Context, mailbox string, uid string)
 		return nil, err
 	}
 
-	// Check if maildir exists
 	curPath := filepath.Join(path, "cur")
 	if _, err := os.Stat(curPath); os.IsNotExist(err) {
 		return nil, errors.ErrMailboxNotFound
 	}
 
-	return s.retrieveFromDir(path, uid)
+	key, err := s.lookupKey(path, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.retrieveFromDir(path, key)
 }
 
 // Delete implements msgstore.MessageStore.
-func (s *MaildirStore) Delete(ctx context.Context, mailbox string, uid string) error {
+func (s *MaildirStore) Delete(ctx context.Context, mailbox string, uid uint32) error {
 	s.deletedMu.Lock()
 	defer s.deletedMu.Unlock()
 
 	if s.deleted[mailbox] == nil {
-		s.deleted[mailbox] = make(map[string]bool)
+		s.deleted[mailbox] = make(map[uint32]bool)
 	}
 	s.deleted[mailbox][uid] = true
 	return nil
@@ -407,13 +496,51 @@ func (s *MaildirStore) Expunge(ctx context.Context, mailbox string) error {
 		return err
 	}
 
-	// Check if maildir exists
 	curPath := filepath.Join(path, "cur")
 	if _, err := os.Stat(curPath); os.IsNotExist(err) {
 		return errors.ErrMailboxNotFound
 	}
 
-	return s.removeMessages(path, deletedUIDs)
+	// Resolve uint32 UIDs to Maildir keys for removal.
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return err
+	}
+	keys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+
+	keysToRemove := make(map[string]bool)
+	for uid := range deletedUIDs {
+		if key, ok := ul.uidToKey[uid]; ok {
+			keysToRemove[key] = true
+		}
+	}
+
+	if err := s.removeMessages(path, keysToRemove); err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+
+	// Reconcile uidlist after removal (removes entries for deleted keys).
+	remainingKeys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+	ul.reconcile(remainingKeys)
+	err = ul.write(path)
+	unlockUIDList(lock)
+
+	s.invalidateUIDListCache(path)
+	return err
 }
 
 // Stat implements msgstore.MessageStore.
@@ -652,9 +779,9 @@ func (s *MaildirStore) StatFolder(ctx context.Context, mailbox string, folder st
 }
 
 // RetrieveFromFolder implements msgstore.FolderStore.
-func (s *MaildirStore) RetrieveFromFolder(ctx context.Context, mailbox string, folder string, uid string) (io.ReadCloser, error) {
-	key := folderDeletionKey(mailbox, folder)
-	if s.isDeleted(key, uid) {
+func (s *MaildirStore) RetrieveFromFolder(ctx context.Context, mailbox string, folder string, uid uint32) (io.ReadCloser, error) {
+	delKey := folderDeletionKey(mailbox, folder)
+	if s.isDeleted(delKey, uid) {
 		return nil, errors.ErrMessageDeleted
 	}
 
@@ -668,33 +795,38 @@ func (s *MaildirStore) RetrieveFromFolder(ctx context.Context, mailbox string, f
 		return nil, errors.ErrFolderNotFound
 	}
 
-	return s.retrieveFromDir(path, uid)
+	key, err := s.lookupKey(path, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.retrieveFromDir(path, key)
 }
 
 // DeleteInFolder implements msgstore.FolderStore.
-func (s *MaildirStore) DeleteInFolder(ctx context.Context, mailbox string, folder string, uid string) error {
+func (s *MaildirStore) DeleteInFolder(ctx context.Context, mailbox string, folder string, uid uint32) error {
 	if err := validateFolderName(folder); err != nil {
 		return err
 	}
 
-	key := folderDeletionKey(mailbox, folder)
+	delKey := folderDeletionKey(mailbox, folder)
 	s.deletedMu.Lock()
 	defer s.deletedMu.Unlock()
 
-	if s.deleted[key] == nil {
-		s.deleted[key] = make(map[string]bool)
+	if s.deleted[delKey] == nil {
+		s.deleted[delKey] = make(map[uint32]bool)
 	}
-	s.deleted[key][uid] = true
+	s.deleted[delKey][uid] = true
 	return nil
 }
 
 // ExpungeFolder implements msgstore.FolderStore.
 func (s *MaildirStore) ExpungeFolder(ctx context.Context, mailbox string, folder string) error {
-	key := folderDeletionKey(mailbox, folder)
+	delKey := folderDeletionKey(mailbox, folder)
 
 	s.deletedMu.Lock()
-	deletedUIDs := s.deleted[key]
-	delete(s.deleted, key)
+	deletedUIDs := s.deleted[delKey]
+	delete(s.deleted, delKey)
 	s.deletedMu.Unlock()
 
 	if len(deletedUIDs) == 0 {
@@ -711,7 +843,46 @@ func (s *MaildirStore) ExpungeFolder(ctx context.Context, mailbox string, folder
 		return errors.ErrFolderNotFound
 	}
 
-	return s.removeMessages(path, deletedUIDs)
+	// Resolve uint32 UIDs to Maildir keys for removal.
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return err
+	}
+	keys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+
+	keysToRemove := make(map[string]bool)
+	for uid := range deletedUIDs {
+		if key, ok := ul.uidToKey[uid]; ok {
+			keysToRemove[key] = true
+		}
+	}
+
+	if err := s.removeMessages(path, keysToRemove); err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+
+	// Reconcile uidlist after removal.
+	remainingKeys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return err
+	}
+	ul.reconcile(remainingKeys)
+	err = ul.write(path)
+	unlockUIDList(lock)
+
+	s.invalidateUIDListCache(path)
+	return err
 }
 
 // DeliverToFolder implements msgstore.FolderStore.
@@ -813,52 +984,74 @@ func moveNewToCurWithFlags(dirPath string, key string, flags []maildir.Flag) err
 }
 
 // AppendToFolder implements msgstore.FolderStore.
-func (s *MaildirStore) AppendToFolder(ctx context.Context, mailbox string, folder string, r io.Reader, flags []string, date time.Time) (string, error) {
+func (s *MaildirStore) AppendToFolder(ctx context.Context, mailbox string, folder string, r io.Reader, flags []string, date time.Time) (uint32, error) {
 	path, err := s.folderOrInboxPath(mailbox, folder)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 
 	dir := maildir.Dir(path)
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return "", err
+		return 0, err
 	}
 	if err := dir.Init(); err != nil && !os.IsExist(err) {
-		return "", err
+		return 0, err
 	}
 
 	// Snapshot new/ before delivery to identify the resulting key.
 	newDir := filepath.Join(path, "new")
 	beforeKeys, err := maildirNewKeys(newDir)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 
 	delivery, err := maildir.NewDelivery(path)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 	if _, err := io.Copy(delivery, r); err != nil {
 		_ = delivery.Abort()
-		return "", err
+		return 0, err
 	}
 	if err := delivery.Close(); err != nil {
-		return "", err
+		return 0, err
 	}
 
 	// Find the newly added key in new/.
 	key, err := maildirNewKey(newDir, beforeKeys)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 
 	// Move from new/ to cur/ with the requested flags. IMAP APPEND messages
 	// are explicitly placed by the client and must be immediately accessible.
 	if err := moveNewToCurWithFlags(path, key, convertFlagsFromIMAP(flags)); err != nil {
-		return "", err
+		return 0, err
 	}
 
-	return key, nil
+	// Assign a UID in the uidlist.
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return 0, err
+	}
+	curKeys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return 0, err
+	}
+	ul, err := loadOrBootstrapUIDList(path, curKeys)
+	unlockUIDList(lock)
+	if err != nil {
+		return 0, err
+	}
+
+	s.invalidateUIDListCache(path)
+
+	uid, ok := ul.keyToUID[key]
+	if !ok {
+		return 0, errors.ErrMessageNotFound
+	}
+	return uid, nil
 }
 
 // maildirNewKeys returns the set of filenames currently in the new/ directory.
@@ -894,120 +1087,193 @@ func maildirNewKey(newDir string, beforeKeys map[string]bool) (string, error) {
 }
 
 // SetFlagsInFolder implements msgstore.FolderStore.
-func (s *MaildirStore) SetFlagsInFolder(ctx context.Context, mailbox string, folder string, uid string, flags []string) error {
+func (s *MaildirStore) SetFlagsInFolder(ctx context.Context, mailbox string, folder string, uid uint32, flags []string) error {
 	path, err := s.folderOrInboxPath(mailbox, folder)
 	if err != nil {
 		return err
 	}
+
+	key, err := s.lookupKey(path, uid)
+	if err != nil {
+		return err
+	}
+
 	mdFlags := convertFlagsFromIMAP(flags)
 	dir := maildir.Dir(path)
 
 	// Try cur/ first (most messages live here).
-	msg, err := dir.MessageByKey(uid)
+	msg, err := dir.MessageByKey(key)
 	if err == nil {
 		return msg.SetFlags(mdFlags)
 	}
 
 	// Fall back to new/: move to cur/ with the requested flags.
-	newPath := filepath.Join(path, "new", uid)
+	newPath := filepath.Join(path, "new", key)
 	if _, statErr := os.Stat(newPath); statErr == nil {
-		return moveNewToCurWithFlags(path, uid, mdFlags)
+		return moveNewToCurWithFlags(path, key, mdFlags)
 	}
 
 	return errors.ErrMessageNotFound
 }
 
 // CopyMessage implements msgstore.FolderStore.
-func (s *MaildirStore) CopyMessage(ctx context.Context, mailbox string, srcFolder string, uid string, destFolder string) (string, error) {
+func (s *MaildirStore) CopyMessage(ctx context.Context, mailbox string, srcFolder string, uid uint32, destFolder string) (uint32, error) {
 	srcPath, err := s.folderOrInboxPath(mailbox, srcFolder)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 	destPath, err := s.folderOrInboxPath(mailbox, destFolder)
 	if err != nil {
-		return "", err
+		return 0, err
+	}
+
+	// Resolve source UID to Maildir key.
+	srcKey, err := s.lookupKey(srcPath, uid)
+	if err != nil {
+		return 0, err
 	}
 
 	// Ensure destination exists.
 	destDir := maildir.Dir(destPath)
 	if err := os.MkdirAll(destPath, 0700); err != nil {
-		return "", err
+		return 0, err
 	}
 	if err := destDir.Init(); err != nil && !os.IsExist(err) {
-		return "", err
+		return 0, err
 	}
 
 	srcDir := maildir.Dir(srcPath)
 
 	// Try cur/ first. CopyTo places the copy in cur/ and returns the new Message.
-	msg, err := srcDir.MessageByKey(uid)
+	msg, err := srcDir.MessageByKey(srcKey)
 	if err == nil {
-		newMsg, err := msg.CopyTo(destDir)
-		if err != nil {
-			return "", err
-		}
-		return newMsg.Key(), nil
-	}
-
-	// Fall back: source is in new/. Read and deliver to destination's new/.
-	newSrcPath := filepath.Join(srcPath, "new", uid)
-	if _, statErr := os.Stat(newSrcPath); statErr != nil {
-		return "", errors.ErrMessageNotFound
-	}
-
-	srcFile, err := os.Open(newSrcPath)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = srcFile.Close() }()
-
-	// Snapshot new/ in destination before delivery.
-	destNewDir := filepath.Join(destPath, "new")
-	beforeKeys, err := maildirNewKeys(destNewDir)
-	if err != nil {
-		return "", err
-	}
-
-	delivery, err := maildir.NewDelivery(destPath)
-	if err != nil {
-		return "", err
-	}
-	if _, err := io.Copy(delivery, srcFile); err != nil {
-		_ = delivery.Abort()
-		return "", err
-	}
-	if err := delivery.Close(); err != nil {
-		return "", err
-	}
-
-	return maildirNewKey(destNewDir, beforeKeys)
-}
-
-// UIDValidity implements msgstore.FolderStore.
-// Returns a stable hash of the folder's base name. For a persistent
-// implementation, see issue #9.
-func (s *MaildirStore) UIDValidity(ctx context.Context, mailbox string, folder string) (uint32, error) {
-	var name string
-	if strings.EqualFold(folder, "INBOX") {
-		path, err := s.mailboxPath(mailbox)
+		_, err := msg.CopyTo(destDir)
 		if err != nil {
 			return 0, err
 		}
-		name = filepath.Base(path)
 	} else {
-		name = folder
+		// Fall back: source is in new/. Read and deliver to destination's new/.
+		newSrcPath := filepath.Join(srcPath, "new", srcKey)
+		if _, statErr := os.Stat(newSrcPath); statErr != nil {
+			return 0, errors.ErrMessageNotFound
+		}
+
+		srcFile, err := os.Open(newSrcPath)
+		if err != nil {
+			return 0, err
+		}
+		defer func() { _ = srcFile.Close() }()
+
+		delivery, err := maildir.NewDelivery(destPath)
+		if err != nil {
+			return 0, err
+		}
+		if _, err := io.Copy(delivery, srcFile); err != nil {
+			_ = delivery.Abort()
+			return 0, err
+		}
+		if err := delivery.Close(); err != nil {
+			return 0, err
+		}
 	}
-	// Strip any maildir++ flag suffix if present.
-	if i := strings.IndexByte(name, ':'); i >= 0 {
-		name = name[:i]
+
+	// Assign a UID in the destination uidlist.
+	lock, err := lockUIDList(destPath)
+	if err != nil {
+		return 0, err
 	}
-	h := fnv.New32a()
-	h.Write([]byte(name))
-	v := h.Sum32()
-	if v == 0 {
-		return 1, nil
+	destKeys, err := curDirKeys(destPath)
+	if err != nil {
+		unlockUIDList(lock)
+		return 0, err
 	}
-	return v, nil
+	ul, err := loadOrBootstrapUIDList(destPath, destKeys)
+	unlockUIDList(lock)
+	if err != nil {
+		return 0, err
+	}
+
+	s.invalidateUIDListCache(destPath)
+
+	// The new message's key will be the highest UID (just assigned by reconcile).
+	// Return uidNext - 1 as the newly assigned UID.
+	newUID := ul.uidNext - 1
+	return newUID, nil
+}
+
+// UIDValidity implements msgstore.FolderStore.
+// Returns the persistent UIDValidity from the .uidlist file.
+// If the file does not exist, bootstraps a new uidlist.
+func (s *MaildirStore) UIDValidity(ctx context.Context, mailbox string, folder string) (uint32, error) {
+	// Ensure the maildir exists so we can create the lock file.
+	if strings.EqualFold(folder, "INBOX") {
+		if _, err := s.ensureMaildir(mailbox); err != nil {
+			return 0, err
+		}
+	} else {
+		if _, err := s.ensureFolderMaildir(mailbox, folder); err != nil {
+			return 0, err
+		}
+	}
+
+	path, err := s.folderOrInboxPath(mailbox, folder)
+	if err != nil {
+		return 0, err
+	}
+
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return 0, err
+	}
+	keys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return 0, err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	unlockUIDList(lock)
+	if err != nil {
+		return 0, err
+	}
+
+	return ul.uidValidity, nil
+}
+
+// UIDNext implements msgstore.FolderStore.
+// Returns the next UID that will be assigned in the folder.
+func (s *MaildirStore) UIDNext(ctx context.Context, mailbox string, folder string) (uint32, error) {
+	// Ensure the maildir exists so we can create the lock file.
+	if strings.EqualFold(folder, "INBOX") {
+		if _, err := s.ensureMaildir(mailbox); err != nil {
+			return 0, err
+		}
+	} else {
+		if _, err := s.ensureFolderMaildir(mailbox, folder); err != nil {
+			return 0, err
+		}
+	}
+
+	path, err := s.folderOrInboxPath(mailbox, folder)
+	if err != nil {
+		return 0, err
+	}
+
+	lock, err := lockUIDList(path)
+	if err != nil {
+		return 0, err
+	}
+	keys, err := curDirKeys(path)
+	if err != nil {
+		unlockUIDList(lock)
+		return 0, err
+	}
+	ul, err := loadOrBootstrapUIDList(path, keys)
+	unlockUIDList(lock)
+	if err != nil {
+		return 0, err
+	}
+
+	return ul.uidNext, nil
 }
 
 // Compile-time interface verification.

--- a/maildir/store_test.go
+++ b/maildir/store_test.go
@@ -1261,8 +1261,8 @@ func TestMaildirStore_AppendToFolder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AppendToFolder: %v", err)
 	}
-	if uid == "" {
-		t.Fatal("expected non-empty UID")
+	if uid == 0 {
+		t.Fatal("expected non-zero UID")
 	}
 
 	msgs, err := store.ListInFolder(ctx, "user@example.com", "archive")
@@ -1294,8 +1294,8 @@ func TestMaildirStore_AppendToFolder_INBOX(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AppendToFolder INBOX: %v", err)
 	}
-	if uid == "" {
-		t.Fatal("expected non-empty UID")
+	if uid == 0 {
+		t.Fatal("expected non-zero UID")
 	}
 
 	msgs, err := store.List(ctx, "user@example.com")
@@ -1365,7 +1365,7 @@ func TestMaildirStore_SetFlagsInFolder_MessageNotFound(t *testing.T) {
 		t.Fatalf("CreateFolder: %v", err)
 	}
 
-	err := store.SetFlagsInFolder(ctx, "user@example.com", "work", "nonexistent-key", []string{"\\Seen"})
+	err := store.SetFlagsInFolder(ctx, "user@example.com", "work", 99999, []string{"\\Seen"})
 	if err != errors.ErrMessageNotFound {
 		t.Fatalf("expected ErrMessageNotFound, got %v", err)
 	}
@@ -1386,8 +1386,8 @@ func TestMaildirStore_CopyMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CopyMessage: %v", err)
 	}
-	if destUID == "" {
-		t.Fatal("expected non-empty dest UID")
+	if destUID == 0 {
+		t.Fatal("expected non-zero dest UID")
 	}
 
 	// Source should still have the message.
@@ -1434,8 +1434,8 @@ func TestMaildirStore_CopyMessage_FromINBOX(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CopyMessage from INBOX: %v", err)
 	}
-	if destUID == "" {
-		t.Fatal("expected non-empty dest UID")
+	if destUID == 0 {
+		t.Fatal("expected non-zero dest UID")
 	}
 
 	dstMsgs, err := store.ListInFolder(ctx, "user@example.com", "archive")
@@ -1456,7 +1456,7 @@ func TestMaildirStore_CopyMessage_NotFound(t *testing.T) {
 		t.Fatalf("CreateFolder: %v", err)
 	}
 
-	_, err := store.CopyMessage(ctx, "user@example.com", "src", "nonexistent", "dst")
+	_, err := store.CopyMessage(ctx, "user@example.com", "src", 99999, "dst")
 	if err != errors.ErrMessageNotFound {
 		t.Fatalf("expected ErrMessageNotFound, got %v", err)
 	}
@@ -1489,16 +1489,9 @@ func TestMaildirStore_UIDValidity(t *testing.T) {
 		t.Errorf("UIDValidity not stable: %d != %d", v1, v2)
 	}
 
-	// Different folder name, different result.
-	if err := store.CreateFolder(ctx, "user@example.com", "archive"); err != nil {
-		t.Fatalf("CreateFolder: %v", err)
-	}
-	vOther, err := store.UIDValidity(ctx, "user@example.com", "archive")
-	if err != nil {
-		t.Fatalf("UIDValidity archive: %v", err)
-	}
-	if v1 == vOther {
-		t.Error("different folders should have different UIDValidity")
+	// Value should be a reasonable Unix timestamp.
+	if v1 < 1_000_000_000 {
+		t.Errorf("UIDValidity should be a Unix timestamp, got %d", v1)
 	}
 }
 
@@ -1726,5 +1719,246 @@ func TestEnsureMaildir_CreatesDefaultFolders(t *testing.T) {
 		if !found[name] {
 			t.Errorf("ensureMaildir did not create default folder %q", name)
 		}
+	}
+}
+
+// --- UID persistence integration tests ---
+
+func TestMaildirStore_UID_StableAcrossListCalls(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	for i := 0; i < 3; i++ {
+		msg := strings.NewReader("Subject: Msg\r\n\r\nBody")
+		if err := store.Deliver(ctx, envelope, msg); err != nil {
+			t.Fatalf("Deliver: %v", err)
+		}
+	}
+
+	msgs1, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List 1: %v", err)
+	}
+	msgs2, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List 2: %v", err)
+	}
+
+	if len(msgs1) != len(msgs2) {
+		t.Fatalf("message counts differ: %d vs %d", len(msgs1), len(msgs2))
+	}
+	for i := range msgs1 {
+		if msgs1[i].UID != msgs2[i].UID {
+			t.Errorf("msg %d: UID %d vs %d", i, msgs1[i].UID, msgs2[i].UID)
+		}
+	}
+}
+
+func TestMaildirStore_UID_StableAfterDeleteExpunge(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	for i := 0; i < 3; i++ {
+		msg := strings.NewReader("Subject: Msg\r\n\r\nBody")
+		if err := store.Deliver(ctx, envelope, msg); err != nil {
+			t.Fatalf("Deliver: %v", err)
+		}
+	}
+
+	msgs, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+
+	// Delete the middle message.
+	if err := store.Delete(ctx, "user@example.com", msgs[1].UID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := store.Expunge(ctx, "user@example.com"); err != nil {
+		t.Fatalf("Expunge: %v", err)
+	}
+
+	remaining, err := store.List(ctx, "user@example.com")
+	if err != nil {
+		t.Fatalf("List after expunge: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(remaining))
+	}
+
+	// UIDs of remaining messages must be unchanged.
+	if remaining[0].UID != msgs[0].UID {
+		t.Errorf("first msg UID changed: %d -> %d", msgs[0].UID, remaining[0].UID)
+	}
+	if remaining[1].UID != msgs[2].UID {
+		t.Errorf("third msg UID changed: %d -> %d", msgs[2].UID, remaining[1].UID)
+	}
+}
+
+func TestMaildirStore_UID_NeverReused(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+
+	// Deliver 2 messages, delete both, deliver a new one.
+	for i := 0; i < 2; i++ {
+		msg := strings.NewReader("Subject: Msg\r\n\r\nBody")
+		if err := store.Deliver(ctx, envelope, msg); err != nil {
+			t.Fatalf("Deliver: %v", err)
+		}
+	}
+
+	msgs, _ := store.List(ctx, "user@example.com")
+	maxUID := msgs[len(msgs)-1].UID
+
+	for _, m := range msgs {
+		if err := store.Delete(ctx, "user@example.com", m.UID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+	}
+	if err := store.Expunge(ctx, "user@example.com"); err != nil {
+		t.Fatalf("Expunge: %v", err)
+	}
+
+	// Deliver a new message.
+	msg := strings.NewReader("Subject: New\r\n\r\nBody")
+	if err := store.Deliver(ctx, envelope, msg); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	newMsgs, _ := store.List(ctx, "user@example.com")
+	if len(newMsgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(newMsgs))
+	}
+	if newMsgs[0].UID <= maxUID {
+		t.Errorf("new UID %d should be greater than previous max %d", newMsgs[0].UID, maxUID)
+	}
+}
+
+func TestMaildirStore_UIDValidity_PersistsAcrossListCalls(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	// Create folder.
+	if err := store.CreateFolder(ctx, "user@example.com", "work"); err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+
+	v1, err := store.UIDValidity(ctx, "user@example.com", "work")
+	if err != nil {
+		t.Fatalf("UIDValidity 1: %v", err)
+	}
+
+	// Deliver a message and list to trigger uidlist activity.
+	if err := store.DeliverToFolder(ctx, "user@example.com", "work", strings.NewReader("Subject: X\r\n\r\nBody")); err != nil {
+		t.Fatalf("DeliverToFolder: %v", err)
+	}
+	if _, err := store.ListInFolder(ctx, "user@example.com", "work"); err != nil {
+		t.Fatalf("ListInFolder: %v", err)
+	}
+
+	v2, err := store.UIDValidity(ctx, "user@example.com", "work")
+	if err != nil {
+		t.Fatalf("UIDValidity 2: %v", err)
+	}
+	if v1 != v2 {
+		t.Errorf("UIDValidity changed: %d -> %d", v1, v2)
+	}
+}
+
+func TestMaildirStore_ExternalFileAddition_GetsUID(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	// Deliver one message to bootstrap the maildir and uidlist.
+	envelope := msgstore.Envelope{
+		From:       "sender@example.com",
+		Recipients: []string{"user@example.com"},
+	}
+	if err := store.Deliver(ctx, envelope, strings.NewReader("Subject: First\r\n\r\nBody")); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	msgs1, _ := store.List(ctx, "user@example.com")
+	if len(msgs1) != 1 {
+		t.Fatalf("expected 1, got %d", len(msgs1))
+	}
+
+	// Simulate external delivery: drop a file directly into cur/.
+	mailboxPath := filepath.Join(basePath, "user", "cur")
+	externalKey := "9999999999.M999999.external"
+	if err := os.WriteFile(filepath.Join(mailboxPath, externalKey+":2,"), []byte("Subject: External\r\n\r\nBody"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// List should pick it up with a new UID via reconciliation.
+	msgs2, _ := store.List(ctx, "user@example.com")
+	if len(msgs2) != 2 {
+		t.Fatalf("expected 2 after external add, got %d", len(msgs2))
+	}
+
+	// The external file should have a UID > the first message's UID.
+	uids := make(map[uint32]bool)
+	for _, m := range msgs2 {
+		if uids[m.UID] {
+			t.Errorf("duplicate UID %d", m.UID)
+		}
+		uids[m.UID] = true
+	}
+}
+
+func TestMaildirStore_UIDNext(t *testing.T) {
+	basePath := t.TempDir()
+	store := NewStore(basePath, "", "")
+	ctx := context.Background()
+
+	// Create folder and check initial UIDNext.
+	if err := store.CreateFolder(ctx, "user@example.com", "test"); err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+
+	next1, err := store.UIDNext(ctx, "user@example.com", "test")
+	if err != nil {
+		t.Fatalf("UIDNext: %v", err)
+	}
+	if next1 != 1 {
+		t.Errorf("initial UIDNext: got %d, want 1", next1)
+	}
+
+	// Append a message.
+	uid, err := store.AppendToFolder(ctx, "user@example.com", "test", strings.NewReader("Subject: X\r\n\r\nBody"), nil, time.Now())
+	if err != nil {
+		t.Fatalf("AppendToFolder: %v", err)
+	}
+	if uid != 1 {
+		t.Errorf("AppendToFolder UID: got %d, want 1", uid)
+	}
+
+	next2, err := store.UIDNext(ctx, "user@example.com", "test")
+	if err != nil {
+		t.Fatalf("UIDNext after append: %v", err)
+	}
+	if next2 != 2 {
+		t.Errorf("UIDNext after append: got %d, want 2", next2)
 	}
 }

--- a/maildir/uidlist.go
+++ b/maildir/uidlist.go
@@ -1,0 +1,334 @@
+package maildir
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	uidlistFile     = ".uidlist"
+	uidlistTmpFile  = ".uidlist.tmp"
+	uidlistLockFile = ".uidlist.lock"
+	uidlistVersion  = 3
+)
+
+// uidEntry maps a persistent UID to a Maildir filename key.
+type uidEntry struct {
+	uid uint32
+	key string
+}
+
+// uidList maintains the persistent UID-to-key mapping for a single Maildir folder.
+type uidList struct {
+	version     int
+	uidValidity uint32
+	uidNext     uint32
+	entries     []uidEntry        // sorted by UID ascending
+	keyToUID    map[string]uint32 // Maildir key → UID
+	uidToKey    map[uint32]string // UID → Maildir key
+}
+
+// readUIDList parses a .uidlist file from the given Maildir directory.
+// Returns nil if the file does not exist.
+func readUIDList(dirPath string) (*uidList, error) {
+	path := filepath.Join(dirPath, uidlistFile)
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+
+	// Parse header line: "3 V<uidvalidity> N<uidnext>"
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("uidlist: empty file")
+	}
+	header := scanner.Text()
+	ul, err := parseHeader(header)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse entry lines: "<uid> <key>"
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		entry, err := parseEntry(line)
+		if err != nil {
+			return nil, fmt.Errorf("uidlist: %w", err)
+		}
+		ul.entries = append(ul.entries, entry)
+		ul.keyToUID[entry.key] = entry.uid
+		ul.uidToKey[entry.uid] = entry.key
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return ul, nil
+}
+
+// parseHeader parses the header line "3 V<validity> N<next>".
+func parseHeader(line string) (*uidList, error) {
+	parts := strings.Fields(line)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("uidlist: invalid header: %q", line)
+	}
+
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("uidlist: invalid version: %q", parts[0])
+	}
+
+	if !strings.HasPrefix(parts[1], "V") {
+		return nil, fmt.Errorf("uidlist: invalid validity field: %q", parts[1])
+	}
+	validity, err := strconv.ParseUint(parts[1][1:], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("uidlist: invalid validity value: %q", parts[1])
+	}
+
+	if !strings.HasPrefix(parts[2], "N") {
+		return nil, fmt.Errorf("uidlist: invalid next field: %q", parts[2])
+	}
+	next, err := strconv.ParseUint(parts[2][1:], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("uidlist: invalid next value: %q", parts[2])
+	}
+
+	return &uidList{
+		version:     version,
+		uidValidity: uint32(validity),
+		uidNext:     uint32(next),
+		keyToUID:    make(map[string]uint32),
+		uidToKey:    make(map[uint32]string),
+	}, nil
+}
+
+// parseEntry parses an entry line "<uid> <key>".
+func parseEntry(line string) (uidEntry, error) {
+	idx := strings.IndexByte(line, ' ')
+	if idx < 0 {
+		return uidEntry{}, fmt.Errorf("invalid entry: %q", line)
+	}
+	uid, err := strconv.ParseUint(line[:idx], 10, 32)
+	if err != nil {
+		return uidEntry{}, fmt.Errorf("invalid uid in entry: %q", line)
+	}
+	key := line[idx+1:]
+	if key == "" {
+		return uidEntry{}, fmt.Errorf("empty key in entry: %q", line)
+	}
+	return uidEntry{uid: uint32(uid), key: key}, nil
+}
+
+// write atomically writes the uidlist to disk.
+// Writes to .uidlist.tmp, fsyncs, then renames over .uidlist.
+func (u *uidList) write(dirPath string) error {
+	tmpPath := filepath.Join(dirPath, uidlistTmpFile)
+	finalPath := filepath.Join(dirPath, uidlistFile)
+
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+
+	w := bufio.NewWriter(f)
+
+	// Header
+	if _, err := fmt.Fprintf(w, "%d V%d N%d\n", u.version, u.uidValidity, u.uidNext); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	// Entries (sorted by UID)
+	for _, e := range u.entries {
+		if _, err := fmt.Fprintf(w, "%d %s\n", e.uid, e.key); err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+			return err
+		}
+	}
+
+	if err := w.Flush(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, finalPath)
+}
+
+// reconcile updates the uidlist against the current set of Maildir keys in cur/.
+// Returns true if any changes were made.
+func (u *uidList) reconcile(curKeys []string) bool {
+	curSet := make(map[string]bool, len(curKeys))
+	for _, k := range curKeys {
+		curSet[k] = true
+	}
+
+	changed := false
+
+	// Remove entries for keys no longer in cur/.
+	var kept []uidEntry
+	for _, e := range u.entries {
+		if curSet[e.key] {
+			kept = append(kept, e)
+		} else {
+			delete(u.keyToUID, e.key)
+			delete(u.uidToKey, e.uid)
+			changed = true
+		}
+	}
+	u.entries = kept
+
+	// Find new keys not yet in the uidlist and sort them for deterministic
+	// UID assignment. Maildir keys begin with a Unix timestamp, so lexicographic
+	// sort gives chronological order.
+	var newKeys []string
+	for _, k := range curKeys {
+		if _, ok := u.keyToUID[k]; !ok {
+			newKeys = append(newKeys, k)
+		}
+	}
+	if len(newKeys) > 0 {
+		sort.Strings(newKeys)
+		for _, k := range newKeys {
+			e := uidEntry{uid: u.uidNext, key: k}
+			u.entries = append(u.entries, e)
+			u.keyToUID[k] = u.uidNext
+			u.uidToKey[u.uidNext] = k
+			u.uidNext++
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+// bootstrapUIDList creates a new uidlist from the current contents of cur/.
+// UIDValidity is set to the current Unix timestamp.
+func bootstrapUIDList(curKeys []string) *uidList {
+	sort.Strings(curKeys)
+
+	ul := &uidList{
+		version:     uidlistVersion,
+		uidValidity: uint32(time.Now().Unix()),
+		uidNext:     1,
+		keyToUID:    make(map[string]uint32, len(curKeys)),
+		uidToKey:    make(map[uint32]string, len(curKeys)),
+	}
+
+	for _, k := range curKeys {
+		e := uidEntry{uid: ul.uidNext, key: k}
+		ul.entries = append(ul.entries, e)
+		ul.keyToUID[k] = ul.uidNext
+		ul.uidToKey[ul.uidNext] = k
+		ul.uidNext++
+	}
+
+	return ul
+}
+
+// lockUIDList acquires an exclusive flock on .uidlist.lock in the given directory.
+// Returns the lock file which must be closed to release the lock.
+func lockUIDList(dirPath string) (*os.File, error) {
+	lockPath := filepath.Join(dirPath, uidlistLockFile)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// unlockUIDList releases the flock and closes the lock file.
+func unlockUIDList(f *os.File) {
+	if f != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}
+
+// loadOrBootstrapUIDList loads the uidlist for a Maildir directory, or
+// bootstraps a new one if the file doesn't exist or is corrupt.
+// curKeys should be the current Maildir keys from cur/.
+// If the uidlist was bootstrapped or reconciled, it is written to disk.
+// Callers must hold the uidlist lock.
+func loadOrBootstrapUIDList(dirPath string, curKeys []string) (*uidList, error) {
+	ul, err := readUIDList(dirPath)
+	if err != nil {
+		// Corrupt file — log warning and bootstrap.
+		_ = os.Remove(filepath.Join(dirPath, uidlistFile))
+		ul = nil
+	}
+
+	if ul == nil {
+		ul = bootstrapUIDList(curKeys)
+		if err := ul.write(dirPath); err != nil {
+			return nil, err
+		}
+		return ul, nil
+	}
+
+	if ul.reconcile(curKeys) {
+		if err := ul.write(dirPath); err != nil {
+			return nil, err
+		}
+	}
+
+	return ul, nil
+}
+
+// curDirKeys returns the Maildir keys for all files in the cur/ subdirectory.
+// The key is the filename up to (but not including) the info separator ':'.
+func curDirKeys(dirPath string) ([]string, error) {
+	curPath := filepath.Join(dirPath, "cur")
+	entries, err := os.ReadDir(curPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Extract key: everything before the ':' info separator.
+		if i := strings.IndexByte(name, ':'); i >= 0 {
+			name = name[:i]
+		}
+		keys = append(keys, name)
+	}
+	return keys, nil
+}

--- a/maildir/uidlist_test.go
+++ b/maildir/uidlist_test.go
@@ -1,0 +1,402 @@
+package maildir
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestReadWriteRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	ul := &uidList{
+		version:     3,
+		uidValidity: 1741824000,
+		uidNext:     4,
+		entries: []uidEntry{
+			{uid: 1, key: "1710339422.M123456.hostname"},
+			{uid: 2, key: "1710339423.M789012.hostname"},
+			{uid: 3, key: "1710339424.M345678.hostname"},
+		},
+		keyToUID: map[string]uint32{
+			"1710339422.M123456.hostname": 1,
+			"1710339423.M789012.hostname": 2,
+			"1710339424.M345678.hostname": 3,
+		},
+		uidToKey: map[uint32]string{
+			1: "1710339422.M123456.hostname",
+			2: "1710339423.M789012.hostname",
+			3: "1710339424.M345678.hostname",
+		},
+	}
+
+	if err := ul.write(dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := readUIDList(dir)
+	if err != nil {
+		t.Fatalf("readUIDList: %v", err)
+	}
+
+	if got.version != ul.version {
+		t.Errorf("version: got %d, want %d", got.version, ul.version)
+	}
+	if got.uidValidity != ul.uidValidity {
+		t.Errorf("uidValidity: got %d, want %d", got.uidValidity, ul.uidValidity)
+	}
+	if got.uidNext != ul.uidNext {
+		t.Errorf("uidNext: got %d, want %d", got.uidNext, ul.uidNext)
+	}
+	if len(got.entries) != len(ul.entries) {
+		t.Fatalf("entries: got %d, want %d", len(got.entries), len(ul.entries))
+	}
+	for i, e := range got.entries {
+		if e.uid != ul.entries[i].uid || e.key != ul.entries[i].key {
+			t.Errorf("entry %d: got {%d, %q}, want {%d, %q}",
+				i, e.uid, e.key, ul.entries[i].uid, ul.entries[i].key)
+		}
+	}
+	// Verify lookup maps.
+	for k, v := range ul.keyToUID {
+		if got.keyToUID[k] != v {
+			t.Errorf("keyToUID[%q]: got %d, want %d", k, got.keyToUID[k], v)
+		}
+	}
+	for k, v := range ul.uidToKey {
+		if got.uidToKey[k] != v {
+			t.Errorf("uidToKey[%d]: got %q, want %q", k, got.uidToKey[k], v)
+		}
+	}
+}
+
+func TestReadUIDListNotExist(t *testing.T) {
+	dir := t.TempDir()
+	ul, err := readUIDList(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ul != nil {
+		t.Fatalf("expected nil for non-existent file, got %+v", ul)
+	}
+}
+
+func TestBootstrapUIDList(t *testing.T) {
+	keys := []string{
+		"1710339424.M345678.hostname",
+		"1710339422.M123456.hostname",
+		"1710339423.M789012.hostname",
+	}
+
+	ul := bootstrapUIDList(keys)
+
+	if ul.version != uidlistVersion {
+		t.Errorf("version: got %d, want %d", ul.version, uidlistVersion)
+	}
+	if ul.uidValidity == 0 {
+		t.Error("uidValidity should not be 0")
+	}
+	// Keys should be sorted, so UIDs assigned in lexicographic order.
+	if len(ul.entries) != 3 {
+		t.Fatalf("entries: got %d, want 3", len(ul.entries))
+	}
+	if ul.entries[0].key != "1710339422.M123456.hostname" || ul.entries[0].uid != 1 {
+		t.Errorf("entry 0: got {%d, %q}", ul.entries[0].uid, ul.entries[0].key)
+	}
+	if ul.entries[1].key != "1710339423.M789012.hostname" || ul.entries[1].uid != 2 {
+		t.Errorf("entry 1: got {%d, %q}", ul.entries[1].uid, ul.entries[1].key)
+	}
+	if ul.entries[2].key != "1710339424.M345678.hostname" || ul.entries[2].uid != 3 {
+		t.Errorf("entry 2: got {%d, %q}", ul.entries[2].uid, ul.entries[2].key)
+	}
+	if ul.uidNext != 4 {
+		t.Errorf("uidNext: got %d, want 4", ul.uidNext)
+	}
+}
+
+func TestBootstrapEmpty(t *testing.T) {
+	ul := bootstrapUIDList(nil)
+	if len(ul.entries) != 0 {
+		t.Errorf("entries: got %d, want 0", len(ul.entries))
+	}
+	if ul.uidNext != 1 {
+		t.Errorf("uidNext: got %d, want 1", ul.uidNext)
+	}
+}
+
+func TestReconcileNewKey(t *testing.T) {
+	ul := &uidList{
+		version:     3,
+		uidValidity: 100,
+		uidNext:     3,
+		entries: []uidEntry{
+			{uid: 1, key: "a"},
+			{uid: 2, key: "b"},
+		},
+		keyToUID: map[string]uint32{"a": 1, "b": 2},
+		uidToKey: map[uint32]string{1: "a", 2: "b"},
+	}
+
+	changed := ul.reconcile([]string{"a", "b", "c"})
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if ul.uidNext != 4 {
+		t.Errorf("uidNext: got %d, want 4", ul.uidNext)
+	}
+	if uid, ok := ul.keyToUID["c"]; !ok || uid != 3 {
+		t.Errorf("keyToUID[c]: got %d, ok=%v", uid, ok)
+	}
+	if len(ul.entries) != 3 {
+		t.Errorf("entries: got %d, want 3", len(ul.entries))
+	}
+}
+
+func TestReconcileKeyRemoved(t *testing.T) {
+	ul := &uidList{
+		version:     3,
+		uidValidity: 100,
+		uidNext:     4,
+		entries: []uidEntry{
+			{uid: 1, key: "a"},
+			{uid: 2, key: "b"},
+			{uid: 3, key: "c"},
+		},
+		keyToUID: map[string]uint32{"a": 1, "b": 2, "c": 3},
+		uidToKey: map[uint32]string{1: "a", 2: "b", 3: "c"},
+	}
+
+	changed := ul.reconcile([]string{"a", "c"})
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	// uidNext must NOT decrease.
+	if ul.uidNext != 4 {
+		t.Errorf("uidNext: got %d, want 4", ul.uidNext)
+	}
+	if len(ul.entries) != 2 {
+		t.Errorf("entries: got %d, want 2", len(ul.entries))
+	}
+	if _, ok := ul.keyToUID["b"]; ok {
+		t.Error("key 'b' should have been removed")
+	}
+	if _, ok := ul.uidToKey[2]; ok {
+		t.Error("uid 2 should have been removed")
+	}
+}
+
+func TestReconcileNoChanges(t *testing.T) {
+	ul := &uidList{
+		version:     3,
+		uidValidity: 100,
+		uidNext:     3,
+		entries: []uidEntry{
+			{uid: 1, key: "a"},
+			{uid: 2, key: "b"},
+		},
+		keyToUID: map[string]uint32{"a": 1, "b": 2},
+		uidToKey: map[uint32]string{1: "a", 2: "b"},
+	}
+
+	changed := ul.reconcile([]string{"a", "b"})
+	if changed {
+		t.Error("expected changed=false when keys match")
+	}
+}
+
+func TestUIDNeverReusedAfterDeletion(t *testing.T) {
+	ul := &uidList{
+		version:     3,
+		uidValidity: 100,
+		uidNext:     4,
+		entries: []uidEntry{
+			{uid: 1, key: "a"},
+			{uid: 2, key: "b"},
+			{uid: 3, key: "c"},
+		},
+		keyToUID: map[string]uint32{"a": 1, "b": 2, "c": 3},
+		uidToKey: map[uint32]string{1: "a", 2: "b", 3: "c"},
+	}
+
+	// Remove "b" (uid 2).
+	ul.reconcile([]string{"a", "c"})
+
+	// Add a new key — must get uid 4, NOT uid 2.
+	ul.reconcile([]string{"a", "c", "d"})
+	if uid := ul.keyToUID["d"]; uid != 4 {
+		t.Errorf("new key got uid %d, want 4 (uid 2 was deleted and must not be reused)", uid)
+	}
+	if ul.uidNext != 5 {
+		t.Errorf("uidNext: got %d, want 5", ul.uidNext)
+	}
+}
+
+func TestCorruptFileRecovery(t *testing.T) {
+	dir := t.TempDir()
+	// Create a maildir cur/ with a file.
+	curDir := filepath.Join(dir, "cur")
+	if err := os.MkdirAll(curDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(curDir, "1710339422.M123456.hostname:2,S"), []byte("msg"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Write garbage to .uidlist.
+	if err := os.WriteFile(filepath.Join(dir, uidlistFile), []byte("garbage"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	keys, err := curDirKeys(dir)
+	if err != nil {
+		t.Fatalf("curDirKeys: %v", err)
+	}
+
+	ul, err := loadOrBootstrapUIDList(dir, keys)
+	if err != nil {
+		t.Fatalf("loadOrBootstrapUIDList: %v", err)
+	}
+	if ul == nil {
+		t.Fatal("expected non-nil uidlist after recovery")
+	}
+	if len(ul.entries) != 1 {
+		t.Errorf("entries: got %d, want 1", len(ul.entries))
+	}
+}
+
+func TestConcurrentWriteSafety(t *testing.T) {
+	dir := t.TempDir()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			lock, err := lockUIDList(dir)
+			if err != nil {
+				t.Errorf("lockUIDList: %v", err)
+				return
+			}
+			defer unlockUIDList(lock)
+
+			ul := &uidList{
+				version:     3,
+				uidValidity: 100,
+				uidNext:     uint32(n + 1),
+				keyToUID:    make(map[string]uint32),
+				uidToKey:    make(map[uint32]string),
+			}
+			if err := ul.write(dir); err != nil {
+				t.Errorf("write: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// File should be valid and parseable.
+	ul, err := readUIDList(dir)
+	if err != nil {
+		t.Fatalf("readUIDList after concurrent writes: %v", err)
+	}
+	if ul == nil {
+		t.Fatal("expected non-nil uidlist")
+	}
+}
+
+func TestCurDirKeys(t *testing.T) {
+	dir := t.TempDir()
+	curDir := filepath.Join(dir, "cur")
+	if err := os.MkdirAll(curDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Create files with maildir naming: key:info
+	for _, name := range []string{"1710339422.M123.host:2,S", "1710339423.M456.host:2,", "1710339424.M789.host"} {
+		if err := os.WriteFile(filepath.Join(curDir, name), []byte(""), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+
+	keys, err := curDirKeys(dir)
+	if err != nil {
+		t.Fatalf("curDirKeys: %v", err)
+	}
+	if len(keys) != 3 {
+		t.Fatalf("got %d keys, want 3", len(keys))
+	}
+
+	// Verify keys strip the info suffix.
+	keySet := make(map[string]bool)
+	for _, k := range keys {
+		keySet[k] = true
+	}
+	for _, want := range []string{"1710339422.M123.host", "1710339423.M456.host", "1710339424.M789.host"} {
+		if !keySet[want] {
+			t.Errorf("missing key %q", want)
+		}
+	}
+}
+
+func TestParseHeaderValid(t *testing.T) {
+	ul, err := parseHeader("3 V1741824000 N42")
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if ul.version != 3 {
+		t.Errorf("version: got %d, want 3", ul.version)
+	}
+	if ul.uidValidity != 1741824000 {
+		t.Errorf("uidValidity: got %d, want 1741824000", ul.uidValidity)
+	}
+	if ul.uidNext != 42 {
+		t.Errorf("uidNext: got %d, want 42", ul.uidNext)
+	}
+}
+
+func TestParseHeaderInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"3",
+		"3 V100",
+		"X V100 N42",
+		"3 100 N42",
+		"3 V100 42",
+		"3 Vabc N42",
+		"3 V100 Nabc",
+	}
+	for _, tc := range cases {
+		_, err := parseHeader(tc)
+		if err == nil {
+			t.Errorf("parseHeader(%q): expected error", tc)
+		}
+	}
+}
+
+func TestParseEntryValid(t *testing.T) {
+	e, err := parseEntry("42 1710339422.M123456.hostname")
+	if err != nil {
+		t.Fatalf("parseEntry: %v", err)
+	}
+	if e.uid != 42 {
+		t.Errorf("uid: got %d, want 42", e.uid)
+	}
+	if e.key != "1710339422.M123456.hostname" {
+		t.Errorf("key: got %q", e.key)
+	}
+}
+
+func TestParseEntryInvalid(t *testing.T) {
+	cases := []string{
+		"",
+		"42",
+		"abc key",
+		"42 ", // empty key after space — tricky, but we strip to empty
+	}
+	for _, tc := range cases {
+		_, err := parseEntry(tc)
+		if err == nil {
+			t.Errorf("parseEntry(%q): expected error", tc)
+		}
+	}
+}

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -77,7 +77,7 @@ func listMailbox(t *testing.T, cfg msgstore.StoreConfig, mailbox string) []msgst
 }
 
 // retrieveMessage opens a fresh store and retrieves the full message content.
-func retrieveMessage(t *testing.T, cfg msgstore.StoreConfig, mailbox, uid string) string {
+func retrieveMessage(t *testing.T, cfg msgstore.StoreConfig, mailbox string, uid uint32) string {
 	t.Helper()
 	store, err := msgstore.Open(cfg)
 	if err != nil {
@@ -85,7 +85,7 @@ func retrieveMessage(t *testing.T, cfg msgstore.StoreConfig, mailbox, uid string
 	}
 	rc, err := store.Retrieve(context.Background(), mailbox, uid)
 	if err != nil {
-		t.Fatalf("Retrieve %s/%s: %v", mailbox, uid, err)
+		t.Fatalf("Retrieve %s/%d: %v", mailbox, uid, err)
 	}
 	defer func() { _ = rc.Close() }()
 	data, err := io.ReadAll(rc)
@@ -181,7 +181,7 @@ func TestRoundTrip_MultipleMessages(t *testing.T) {
 	for _, m := range msgs {
 		content := retrieveMessage(t, cfg, "carol@test.local", m.UID)
 		if content == "" {
-			t.Errorf("message %s retrieved empty content", m.UID)
+			t.Errorf("message %d retrieved empty content", m.UID)
 		}
 	}
 }
@@ -200,8 +200,8 @@ func TestRoundTrip_SizeReported(t *testing.T) {
 	if msgs[0].Size == 0 {
 		t.Error("MessageInfo.Size should be non-zero")
 	}
-	if msgs[0].UID == "" {
-		t.Error("MessageInfo.UID should be non-empty")
+	if msgs[0].UID == 0 {
+		t.Error("MessageInfo.UID should be non-zero")
 	}
 }
 

--- a/store.go
+++ b/store.go
@@ -14,11 +14,11 @@ type MessageStore interface {
 
 	// Retrieve returns the full message content.
 	// The caller is responsible for closing the returned ReadCloser.
-	Retrieve(ctx context.Context, mailbox string, uid string) (io.ReadCloser, error)
+	Retrieve(ctx context.Context, mailbox string, uid uint32) (io.ReadCloser, error)
 
 	// Delete marks a message for deletion.
 	// The message is not permanently removed until Expunge is called.
-	Delete(ctx context.Context, mailbox string, uid string) error
+	Delete(ctx context.Context, mailbox string, uid uint32) error
 
 	// Expunge permanently removes all messages marked for deletion.
 	Expunge(ctx context.Context, mailbox string) error
@@ -30,8 +30,11 @@ type MessageStore interface {
 
 // MessageInfo contains metadata about a stored message.
 type MessageInfo struct {
-	// UID is the unique identifier for the message within the mailbox.
-	UID string
+	// UID is the persistent numeric IMAP UID assigned by the uidlist.
+	UID uint32
+
+	// Key is the storage key (Maildir filename); opaque to consumers.
+	Key string
 
 	// Size is the message size in bytes.
 	Size int64
@@ -68,11 +71,11 @@ type FolderStore interface {
 
 	// RetrieveFromFolder returns the full message content from a folder.
 	// The caller is responsible for closing the returned ReadCloser.
-	RetrieveFromFolder(ctx context.Context, mailbox string, folder string, uid string) (io.ReadCloser, error)
+	RetrieveFromFolder(ctx context.Context, mailbox string, folder string, uid uint32) (io.ReadCloser, error)
 
 	// DeleteInFolder marks a message in a folder for deletion.
 	// The message is not permanently removed until ExpungeFolder is called.
-	DeleteInFolder(ctx context.Context, mailbox string, folder string, uid string) error
+	DeleteInFolder(ctx context.Context, mailbox string, folder string, uid uint32) error
 
 	// ExpungeFolder permanently removes all messages marked for deletion in a folder.
 	ExpungeFolder(ctx context.Context, mailbox string, folder string) error
@@ -91,22 +94,26 @@ type FolderStore interface {
 	// Used by the IMAP APPEND command. Returns the UID assigned to the new message.
 	// Distinct from DeliverToFolder which is for smtpd routing (no flags/date control).
 	// folder may be "INBOX" to append to the inbox.
-	AppendToFolder(ctx context.Context, mailbox string, folder string, r io.Reader, flags []string, date time.Time) (uid string, err error)
+	AppendToFolder(ctx context.Context, mailbox string, folder string, r io.Reader, flags []string, date time.Time) (uid uint32, err error)
 
 	// SetFlagsInFolder replaces the complete flag set on a message.
 	// flags uses IMAP flag strings (e.g. "\\Seen", "\\Deleted", "\\Answered").
 	// folder may be "INBOX" to operate on inbox messages.
-	SetFlagsInFolder(ctx context.Context, mailbox string, folder string, uid string, flags []string) error
+	SetFlagsInFolder(ctx context.Context, mailbox string, folder string, uid uint32, flags []string) error
 
 	// CopyMessage copies a message to another folder within the same mailbox.
 	// Returns the UID assigned to the copy in destFolder.
 	// srcFolder may be "INBOX"; destFolder may be "INBOX".
-	CopyMessage(ctx context.Context, mailbox string, srcFolder string, uid string, destFolder string) (newUID string, err error)
+	CopyMessage(ctx context.Context, mailbox string, srcFolder string, uid uint32, destFolder string) (newUID uint32, err error)
 
 	// UIDValidity returns the UIDValidity value for a folder.
 	// The value must remain constant for a given folder as long as UIDs have
 	// not been reassigned. folder may be "INBOX".
 	UIDValidity(ctx context.Context, mailbox string, folder string) (uint32, error)
+
+	// UIDNext returns the next UID that will be assigned in the folder.
+	// folder may be "INBOX".
+	UIDNext(ctx context.Context, mailbox string, folder string) (uint32, error)
 }
 
 // FolderSpec defines a default folder with an optional IMAP SPECIAL-USE attribute (RFC 6154).


### PR DESCRIPTION
## Summary

- Implements persistent uint32 UIDs for Maildir messages via `.uidlist` files per folder
- Changes `MessageInfo.UID` from `string` to `uint32`, adds `Key` field for internal Maildir key
- All interface methods: `uid string` → `uid uint32`
- New `FolderStore.UIDNext()` method
- `UIDValidity()` returns persistent value from `.uidlist` header (Unix timestamp)
- Reconciliation on List: new files get UIDs, missing files get removed
- Atomic writes with flock for concurrent safety
- UIDs never reused after deletion

## Test plan

- [x] uidlist read/write round-trip
- [x] Bootstrap from empty dir and from existing messages
- [x] Reconcile: new key added, key removed, no changes
- [x] Concurrent write safety (flock)
- [x] Corrupt file recovery via re-bootstrap
- [x] UID never reused after deletion
- [x] Stable UIDs across List calls
- [x] Stable UIDs after delete+expunge
- [x] External file addition triggers reconciliation with new UID
- [x] UIDValidity persists across operations
- [x] UIDNext increments correctly
- [x] All existing tests updated and passing
- [x] Lint clean (0 issues)

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)