### PR TITLE
Bump Go to 1.26.3 for stdlib CVE fixes

### DIFF
--- a/decrypting_store_test.go
+++ b/decrypting_store_test.go
@@ -136,4 +136,3 @@ func TestPassthroughDecryptingStore_SatisfiesDecryptingStore(_ *testing.T) {
 
 // Ensure mockStore satisfies MessageStore at compile time.
 var _ MessageStore = (*mockStore)(nil)
-

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/infodancer/msgstore
 
-go 1.24.0
-
-toolchain go1.24.4
+go 1.26.3
 
 require (
 	git.sr.ht/~emersion/go-sieve v0.0.0-20240926192256-cf8e1a9b5da9


### PR DESCRIPTION
Closes seven stdlib CVEs reachable from consumers of this package: GO-2026-4865, 4866, 4870, 4918, 4946, 4947, 4971. govulncheck clean.

Also folds in gofmt drift in decrypting_store_test.go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)